### PR TITLE
PvE Balance overhaul

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/blinddog.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/blinddog.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: STBaseMobMutant
   id: MobMutantBlindDog
-  name: слепой пёс
+  name: blind dog
   suffix: ST, T1
-  description: The most common mutant in the zone. They are not as dangerous alone as in a dense flock.
+  description: The most common mutant in the zone. They are not as dangerous alone as in a dense flock, and can be killed handily with a blade if you have the courage.
   components:
     - type: Damageable
       damageModifierSet: STMutantT1DamageModifierSet
@@ -80,17 +80,17 @@
 - type: entity
   parent: MobMutantBlindDog
   id: MobMutantBlindDogPackHead
-  name: глава стаи слепой пёс
+  name: blind dog alpha
   description: the leader of blind dog's pack
   components:
     - type: Butcherable
       spawned:
         - id: MutantPartBlindDogTail
           amount: 2
-          prob: 0.7
+          prob: 1
         - id: FoodMeatDog
           maxAmount: 3
-          prob: 0.7
+          prob: 1
     - type: Sprite
       sprite: /Textures/_Stalker/Mobs/Mutants/blinddog.rsi
       layers:
@@ -101,7 +101,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 200
+            damage: 120
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -109,4 +109,4 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        160: Dead
+        120: Dead

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/boar.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantBoar
-  name: кабан
+  name: Boar
   suffix: ST, T1
   description: A large and aggressive mutant beast, mutated from a wild boar. A beast weighing three hundred kilos is not your toy!
   components:
@@ -51,13 +51,13 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        300: Dead
+        200: Dead
     - type: MeleeWeapon
       attackRate: 0.4
       heavyWindupModifier: 1
       heavyDamageModifier: 1.5
       angle: 30
-      range: 1.5
+      range: 1.15
       soundHit:
         path: /Audio/_Stalker/Mutants/boar_attack_1.ogg
         params:
@@ -82,7 +82,7 @@
           scale: 1, 1
     - type: SlowOnDamage
       speedModifierThresholds:
-        300: 0.7
+        200: 0.7
     - type: StaminaDamageOnHit
       damage: 10
     - type: STWeight

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/bush.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/bush.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantBush
-  name: куст
+  name: Bush
   suffix: ST, T1
-  description: Wait, is he moving?
+  description: Wait, is it moving?
   components:
     - type: Butcherable
       spawned:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantFleshNeutral
-  name: плоть
+  name: flesh
   suffix: ST, T1
   description: Flesh - pigs mutated beyond recognition, one of the most harmless mutants in the Zone.
   components:
@@ -14,7 +14,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 200
+            damage: 100
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -33,7 +33,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        200: Dead
+        100: Dead
     - type: NpcFactionMember
       factions:
         - Passive

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
@@ -14,7 +14,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 100
+            damage: 150
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -33,7 +33,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        100: Dead
+        150: Dead
     - type: NpcFactionMember
       factions:
         - Passive

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rat.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rat.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantRat
-  name: крыса
+  name: rat
   suffix: ST, T1
-  description: Злая, голодная, большая крыса.
+  description: A large, hungry, ferocious rat.
   components:
   - type: Fixtures
     fixtures:
@@ -36,7 +36,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 15
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -45,7 +45,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      25: Dead
+      15: Dead
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
@@ -53,8 +53,8 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 8
-        Caustic: 2
+        Slash: 10
+      #  Caustic: 2 [EN] -- Rats don't do caustic damage.
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.2
     baseSprintSpeed: 4

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rodent.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/rodent.yml
@@ -3,7 +3,7 @@
   id: MobMutantRodent
   suffix: ST, T1
   parent: BaseMobMutant
-  description: A small rodent that is ready to gnaw right through your flesh.
+  description: A mutated rodent the size of a beagle that is ready to gnaw right through your flesh.
   components:
   - type: Damageable
     damageModifierSet: STMutantT1DamageModifierSet
@@ -51,8 +51,8 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 7
-        Blunt: 5
+        Slash: 15
+      #  Blunt: 5
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/spider.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/spider.yml
@@ -2,7 +2,8 @@
   parent: BaseMobMutant
   id: MobMutantSpiderLapach
   suffix: ST, T1
-  name: Паук Лапач
+  description: A large, hideous spider with acidic blood and strong venom. Careless Stalkers who get stuck in its webs make easy prey.
+  name: glutton
   components:
     - type: Damageable
       damageModifierSet: STMutantT1DamageModifierSet
@@ -49,7 +50,7 @@
           volume: 0
           variation: 0.3
     - type: MeleeWeapon
-      attackRate: 1
+      attackRate: 0.85
       heavyWindupModifier: 1
       heavyDamageModifier: 1.5
       angle: 30
@@ -66,14 +67,14 @@
       wideAnimation: WeaponArcClaw
       damage:
         types:
-          Slash: 15
-          Poison: 2
+          Piercing: 5
+          Poison: 15
     - type: MovementSpeedModifier
       baseWalkSpeed: 3
       baseSprintSpeed: 7
     - type: Sprite
       sprite: /Textures/_Stalker/Mobs/Mutants/spiderlapach.rsi
-      scale: 0.5, 0.5
+      scale: 0.75, 0.75
       drawdepth: SmallMobs
       layers:
         - map: ["enum.DamageStateVisualLayers.Base"]

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/boar.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantSeasonedBoar
-  name: матёрый кабан
+  name: Mature Boar
   suffix: ST, T2
-  description: A large and aggressive mutant beast, mutated from a wild boar. A beast weighing three hundred kilos is not your toy!
+  description: A large and aggressive mutant beast, mutated from a wild boar. This one weighs at least 500 kilos. Good eating!
   components:
     - type: Damageable
       damageModifierSet: STMutantBoarDamageModifierSet
@@ -11,6 +11,8 @@
       spawned:
         - id: MutantPartSeasonedBoarHoof
         - id: FoodMeatBoar
+          maxAmount: 5
+          prob: 0.55
         - id: CraftHide
           maxAmount: 1
           prob: 0.25
@@ -57,7 +59,7 @@
       heavyWindupModifier: 1
       heavyDamageModifier: 1.5
       angle: 30
-      range: 1.5
+      range: 1.15
       soundHit:
         path: /Audio/_Stalker/Mutants/boar_attack_1.ogg
         params:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/leshiy.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/leshiy.yml
@@ -1,8 +1,9 @@
 - type: entity
-  name: Леший
+  name: Hamadryad
   parent: BaseMobMutant
   id: MobMutantLeshiy
   suffix: ST, T2
+  description: An arboreal creature resembling a woman crafted of leaves and bark. It contains a strong acid, and it is fond of spitting this at Stalkers.
   components:
   - type: Damageable
     damageModifierSet: STMutantT2DamageModifierSet
@@ -33,7 +34,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead
+      300: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       250: 0.7

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/pseudodog.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/pseudodog.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantPseudodog
-  name: pseudodog
+  name: Pseudodog
   suffix: ST, T2
   description: A mutated wolf that can cause a lot of trouble to an unprepared stalker.
   components:
@@ -31,7 +31,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 250
+            damage: 130
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -39,13 +39,13 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        200: Dead
+        130: Dead
     - type: MeleeWeapon
       attackRate: 1
       heavyWindupModifier: 1
       heavyDamageModifier: 1.5
       angle: 30
-      range: 1.4
+      range: 1.1
       soundHit:
         path: /Audio/_Stalker/Mutants/bdog_hit_0.ogg
         params:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/psidog.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/psidog.yml
@@ -1,12 +1,12 @@
 - type: entity
   parent: STBaseMobMutant
   id: MutantPsidog
-  name: пси-пёс
-  suffix: ST, T2
-  description: Мутировавший волк, обладающий существенными пси-способностями и способный создавать иллюзии. Редкая и очень опасная тварь.
+  name: psy-dog
+  suffix: ST, T3
+  description: A mutated wolf with significant psionic abilities and the ability to create illusions. A rare and very dangerous creature.
   components:
     - type: Damageable
-      damageModifierSet: STMutantT2DamageModifierSet
+      damageModifierSet: STMutantT3DamageModifierSet
     - type: HTN
       rootTask:
         task: STPsidogCompound
@@ -34,7 +34,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        300: Dead
+        150: Dead
     - type: SlowOnDamage
       speedModifierThresholds:
         250: 0.8
@@ -80,7 +80,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 300
+            damage: 150
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -104,9 +104,10 @@
 - type: entity
   parent: STBaseMobMutant
   id: MutantPsidogCopy
-  name: пси-пёс
-  description: Мутировавший волк, обладающий существенными пси-способностями и способный создавать иллюзии. Редкая и очень опасная тварь.
+  name: psy-dog
+  description: A mutated wolf with significant psionic abilities and the ability to create illusions. A rare and very dangerous creature.
   suffix: Stalker, Мутант, Копия
+  # [EN] -- Translation: Mutant, Copies; Left unaltered for code purposes.
   components:
     - type: HTN
       rootTask:
@@ -157,14 +158,15 @@
       wideAnimation: WeaponArcClaw
       damage:
         types:
-          Slash: 8
+          Psy: 5
+          #[EN] Canonically, the Psy-dog's illusions are not supposed to do physical damage because they are not real. The damage should be to the victim's mind, making psy-blockers an important precaution.
     - type: Damageable
       damageModifierSet: CloneMutant
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 25
+            damage: 5
           behaviors:
             - !type:DoActsBehavior
               acts: ["Destruction"]

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/snork.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/snork.yml
@@ -3,13 +3,14 @@
   id: MobMutantSnork
   name: snork
   suffix: ST, T2
-  description: A mutated or crazy person wearing a gas mask is extremely dangerous.
+  description: A mutated, agile once-human crawling on all fours and displaying a blood-soaked grin across a lipless mouth.
   components:
     - type: Butcherable
       spawned:
         - id: MutantPartSnorkFoot
     - type: Damageable
-      damageModifierSet: STMutantT3DamageModifierSet
+      damageModifierSet: STMutantT2DamageModifierSet
+      #[EN] -- Was set to T3 despite being suffixed as T2. This has been changed.
     - type: DamageStateVisuals
       states:
         Alive:
@@ -22,7 +23,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 250
+            damage: 150
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -41,8 +42,9 @@
     - type: Jumpscare
       chargeDamage:
         types:
-          Blunt: 12
-          Slash: 30
+          Blunt: 30
+          Slash: 15
+          #[EN] A snork's legs are by far its deadliest weapon, and they are typically clad in steel-toed boots. Blunt and slash inverted, slash slightly increased.
       jumpPower: 6
       jumpDistance: 10
       updateCooldown: 0.5
@@ -51,7 +53,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        250: Dead
+        150: Dead
     - type: MeleeWeapon
       attackRate: 0.5
       heavyWindupModifier: 1
@@ -70,7 +72,8 @@
       wideAnimation: WeaponArcClaw
       damage:
         types:
-          Slash: 25
+          Slash: 10
+          #[EN] The snork primarily attacks by leaping in the source material, using its legs to kick victims to the ground before slashing them. Snorks should be at their weakest at point-blank range.
     - type: MovementSpeedModifier
       baseWalkSpeed: 3.8
       baseSprintSpeed: 4.4
@@ -89,7 +92,7 @@
           state: snork
     - type: SlowOnDamage
       speedModifierThresholds:
-        200: 0.7
+        100: 0.7
     - type: StaminaDamageOnHit
       damage: 5
     - type: STWeight

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
@@ -16,8 +16,7 @@
     - type: Butcherable
       spawned:
         - id: MutantPartBloodsuckerTentacles
-          maxAmount: 4
-          prob: 0.55
+          maxAmount: 1
         - id: CraftHideBloodSucker
           maxAmount: 1
           prob: 0.30

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/bloodsucker.yml
@@ -3,7 +3,7 @@
   id: MobMutantBloodsucker
   name: bloodsucker
   suffix: ST, T3
-  description: A humanoid mutant with abilities beyond the biological capabilities of earthly species.
+  description: A humanoid mutant with a face full of tentacles, capable of hiding itself from the naked eye. It has an appetite for blood.
   components:
     - type: HTN
       rootTask:
@@ -16,8 +16,8 @@
     - type: Butcherable
       spawned:
         - id: MutantPartBloodsuckerTentacles
-          maxAmount: 1
-          prob: 0.9
+          maxAmount: 4
+          prob: 0.55
         - id: CraftHideBloodSucker
           maxAmount: 1
           prob: 0.30
@@ -28,13 +28,15 @@
       stunTime: 2
       damageOnSuck:
         types:
-          Bloodloss: 17
-        ModifyBloodLevel: -30
+          Piercing: 5
+          Bloodloss: 10
+        ModifyBloodLevel: -50
       healOnSuck:
         groups:
-          Brute: -258
-          Burn: -258
-        ModifyBloodLevel: 133
+          Brute: -50
+          Burn: -50
+        ModifyBloodLevel: 100
+        #[EN] -- 1/3rd of special attack bloodloss converted to piercing, blood level effect on victim increased, healing and blood recovery on self reduced.
     - type: DamageStateVisuals
       states:
         Alive:
@@ -105,7 +107,7 @@
         types:
           Blunt: 35
           Slash: 15
-          Bloodloss: 7
+          # [EN] -- Bloodloss removed from base attack
     - type: MovementSpeedModifier
       baseWalkSpeed: 2.3
       baseSprintSpeed: 5.6
@@ -119,7 +121,8 @@
           sprite: /Textures/_Stalker/Mobs/Mutants/bloodsucker.rsi
           scale: 1.15, 1.15
     - type: StaminaDamageOnHit
-      damage: 13
+      damage: 10
+      #[EN] -- Stamina damage reduced slightly
     - type: Stealth
     - type: StealthOnMove
       passiveVisibilityRate: 0.8

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/boar.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantOldBoar
-  name: старый кабан
+  name: elder boar
   suffix: ST, T3
-  description: A large and aggressive mutant beast, mutated from a wild boar. A beast weighing three hundred kilos is not your toy!
+  description: A large and aggressive mutant beast, mutated from a wild boar. A beast weighing a thousand kilos!
   components:
     - type: Damageable
       damageModifierSet: STMutantBoarDamageModifierSet
@@ -11,6 +11,8 @@
       spawned:
         - id: MutantPartOldBoarHoof
         - id: FoodMeatBoar
+          maxAmount: 10
+          prob: 0.75
         - id: CraftHide
           maxAmount: 1
           prob: 0.25
@@ -26,7 +28,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 450
+            damage: 600
           behaviors:
             - !type:PlaySoundBehavior
               sound:
@@ -51,13 +53,13 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        450: Dead
+        600: Dead
     - type: MeleeWeapon
       attackRate: 0.4
       heavyWindupModifier: 1
       heavyDamageModifier: 1.5
       angle: 30
-      range: 1.5
+      range: 1.15
       soundHit:
         path: /Audio/_Stalker/Mutants/boar_attack_1.ogg
         params:
@@ -92,7 +94,7 @@
         types:
           Blunt: 25
       jumpPower: 2
-      jumpDistance: 4 
+      jumpDistance: 4
       updateCooldown: 0.25
       totalSteps: 6
       stepInterval: 0.001

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: STMutantByurer
   parent: BaseMobMutant
-  name: бюрер
+  name: burer
   suffix: ST, T3
-  description: C какой-то стороны удачный эксперимент учёных по добавлению пси способностей монстрам
+  description: A squat, carrion-feeding humanoid that lurks in dark places. In some ways, this is a successful experiment by scientists to add psy abilities to monsters.
   components:
   - type: Sprite
     sprite: _Stalker/Mobs/Mutants/byurer.rsi

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/controller.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/controller.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: STMutantController
   parent: BaseMobMutant
-  name: контроллёр
+  name: controller
   suffix: ST, T3
-  description: C какой-то стороны удачный эксперимент учёных по добавлению пси способностей монстрам
+  description: A larger, misshapen humanoid mutant with an enlarged cranium and powerful psy-abilities. It is said one can go crazy just by being near one for too long, to say nothing for those who become its victims.
   components:
   - type: Damageable
     damageModifierSet: STMutantT3DamageModifierSet

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
@@ -48,7 +48,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        600: Dead
+        800: Dead
     - type: SlowOnDamage
       speedModifierThresholds:
         600: 0.6

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
@@ -1,9 +1,9 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantOraclesBrown
-  name: оракл
+  name: oracle
   suffix: ST, T3
-  description: Огромных размеров жаба, в животе которой поместиться не один кабан.
+  description: A huge toad, in whose belly more than one wild boar could fit.
   components:
     - type: Butcherable
       spawned:
@@ -48,7 +48,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        800: Dead
+        600: Dead
     - type: SlowOnDamage
       speedModifierThresholds:
         600: 0.6

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/zombie.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/zombie.yml
@@ -1,9 +1,9 @@
 - type: entity
-  name: зомбированный
+  name: zombified stalker
   suffix: Stalker, Т3
   parent: BaseMobMutant
   id: MobStalkerZombieBase
-  description:
+  description: Some poor sod who was caught out in an Emission or got too close to the Brain Scorcher. They are beyond saving, and it is a kindness to kill them.
   components:
     - type: Stamina
       decay: 14

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/goliath.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/goliath.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: STMutantGoliath
   parent: BaseMobMutant
-  name: голиаф
+  name: goliath
   suffix: ST, T4
-  description: Незаконорожденный ребёнок Ньярлатотепа
+  description: The illegitimate child of an eldritch monstrosity. The madness of the Zone made flesh.
   components:
   - type: Damageable
     damageModifierSet: STMutantT4DamageModifierSet

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/gosha.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/gosha.yml
@@ -61,7 +61,7 @@
     - type: MeleeWeapon
       attackRate: 1
       angle: 120
-      range: 1.25
+      range: 1.15
       soundHit:
         path: /Audio/_Stalker/Mutated/Gosha/gosha_beat.ogg
         params:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/pseudogiant.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T4/pseudogiant.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseMobMutant
   id: MobMutantPseudogiant
-  name: псевдогигант
+  name: pseudogiant
   suffix: ST, T4
   description: A massive, terrifying mutant that towers over other creatures in the Zone.
   components:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/mutantsDamageModifySets.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/mutantsDamageModifySets.yml
@@ -14,6 +14,7 @@
     Compression: 5
     Psy: 0
     Mutant: 1
+    Bloodloss: 0
   flatReductions:
     Blunt: 5
 
@@ -32,12 +33,13 @@
     Mutant: 1
   flatReductions:
     Blunt: 29
-    Slash: 29
+  # [EN]Mutants will no longer receive flat reduction of slashing. Most will actually be weaker to slashing and suffer more from bloodloss as they increase in tier.
 
 - type: damageModifierSet
   id: STMutantBoarDamageModifierSet
   class: 0
   coefficients:
+    Slash: 1.5
     Heat: 0.2
     Cold: 0.2
     Poison: 0
@@ -47,14 +49,16 @@
     Compression: 5
     Psy: 0
     Mutant: 1
+    Bloodloss: 5
+    #[EN] Are you familiar with the phrase, "Bleeding like a stuck pig?"
   flatReductions:
     Blunt: 5
-    Slash: 5
 
 - type: damageModifierSet
   id: STMutantT1DamageModifierSet
   class: 0
   coefficients:
+    Slash: 3
     Heat: 0.2
     Cold: 0.2
     Poison: 0
@@ -66,15 +70,15 @@
     Mutant: 1
   flatReductions:
     Blunt: 5
-    Slash: 5
 
 - type: damageModifierSet
   id: STMutantT2DamageModifierSet
   class: 2
   coefficients:
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.3
+    Blunt: 0.75
+    Slash: 2.5
+    Piercing: 0.75
+    #[EN] -- T2 mutants should not take 70% less bullet damage. This is super punishing to rookies who may encounter them right out of the Cordon.
     Heat: 0.2
     Cold: 0.2
     Poison: 0
@@ -84,17 +88,17 @@
     Compression: 5
     Psy: 0
     Mutant: 1
+    Bloodloss: 2
   flatReductions:
     Blunt: 5
-    Slash: 5
 
 - type: damageModifierSet
   id: STMutantT3DamageModifierSet
   class: 3
   coefficients:
     Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.3
+    Slash: 1.5
+    Piercing: 0.5
     Heat: 0.2
     Cold: 0.2
     Poison: 0
@@ -104,16 +108,16 @@
     Compression: 5
     Psy: 0
     Mutant: 1
+    Bloodloss: 3
   flatReductions:
     Blunt: 5
-    Slash: 5
 
 - type: damageModifierSet
   id: STMutantT4DamageModifierSet
   class: 4
   coefficients:
-    Blunt: 0.5
-    Slash: 0.5
+    Blunt: 0.25
+    Slash: 1.25
     Piercing: 0.3
     Heat: 0.2
     Cold: 0.2
@@ -124,6 +128,6 @@
     Compression: 5
     Psy: 0
     Mutant: 1
+    Bloodloss: 4
   flatReductions:
     Blunt: 5
-    Slash: 5

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Melee/knifes.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Melee/knifes.yml
@@ -19,7 +19,6 @@
     damage:
       types:
         Slash: 25
-      #[EN] -- Slightly farther than a dog can reach, increased damage by 5, increased attack speed bonus from 10% to 30%
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit
@@ -31,37 +30,30 @@
   - type: DisarmMalus
     malus: 0.225
 
-  - type: entity
-    name: kukri knife
-    parent: STCombatKnife
-    id: STKukriKnife
-    suffix: ST, T1
-    description: A longer knife with a forward-angled edge for better cutting, but not so good for throwing.
-    components:
-    - type: Tag
-      tags:
-      - STKukriKnife
-      - Knife
-    - type: Sprite
-      sprite: Objects/Weapons/Melee/kukri_knife.rsi
-      state: icon
-    - type: MeleeWeapon
-      wideAnimationRotation: -135
-      range: 1.2
-      attackRate: 1.20
-      damage:
-        types:
-          Slash: 35
-    - type: EmbeddableProjectile
-      sound: /Audio/Weapons/star_hit.ogg
-    - type: DamageOtherOnHit
-      damage:
-        types:
-          Slash: 20
-    - type: Item
-      sprite: Objects/Weapons/Melee/kukri_knife.rsi
-    - type: DisarmMalus
-      malus: 0.225
+- type: entity
+  name: kukri knife
+  parent: STCombatKnife
+  id: STKukriKnife
+  description: A longer knife with a forward-angled edge for better cutting, but not so good for throwing.
+  suffix: ST, T1
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/kukri_knife.rsi
+    state: icon
+  - type: Item
+    sprite: Objects/Weapons/Melee/kukri_knife.rsi
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: 1.2
+    damage:
+      types:
+        Slash: 35
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 20
 
 - type: entity
   name: hunter machete
@@ -72,10 +64,10 @@
   components:
   - type: Tag
     tags:
-    - STHunterMachete
+    - STCombatKnife
     - Knife
   - type: Sprite
-    sprite: Objects/Weapons/Melee/combat_knife.rsi
+    sprite: Objects/Weapons/Melee/machete.rsi
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
@@ -93,7 +85,7 @@
       types:
         Slash: 25
   - type: Item
-    sprite: Objects/Weapons/Melee/combat_knife.rsi
+    sprite: Objects/Weapons/Melee/machete.rsi
   - type: DisarmMalus
     malus: 0.225
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Melee/knifes.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Melee/knifes.yml
@@ -14,16 +14,84 @@
     state: icon
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 1.1
+    range: 1.15
+    attackRate: 1.3
     damage:
       types:
-        Slash: 20
+        Slash: 25
+      #[EN] -- Slightly farther than a dog can reach, increased damage by 5, increased attack speed bonus from 10% to 30%
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit
     damage:
       types:
         Slash: 31
+  - type: Item
+    sprite: Objects/Weapons/Melee/combat_knife.rsi
+  - type: DisarmMalus
+    malus: 0.225
+
+  - type: entity
+    name: kukri knife
+    parent: STCombatKnife
+    id: STKukriKnife
+    suffix: ST, T1
+    description: A longer knife with a forward-angled edge for better cutting, but not so good for throwing.
+    components:
+    - type: Tag
+      tags:
+      - STKukriKnife
+      - Knife
+    - type: Sprite
+      sprite: Objects/Weapons/Melee/kukri_knife.rsi
+      state: icon
+    - type: MeleeWeapon
+      wideAnimationRotation: -135
+      range: 1.2
+      attackRate: 1.20
+      damage:
+        types:
+          Slash: 35
+    - type: EmbeddableProjectile
+      sound: /Audio/Weapons/star_hit.ogg
+    - type: DamageOtherOnHit
+      damage:
+        types:
+          Slash: 20
+    - type: Item
+      sprite: Objects/Weapons/Melee/kukri_knife.rsi
+    - type: DisarmMalus
+      malus: 0.225
+
+- type: entity
+  name: hunter machete
+  parent: [BaseKnife, BaseRestrictedContraband]
+  id: STHunterMachete
+  suffix: ST, T2
+  description: A chopping blade akin to a short sword, serrated and deadly. It tears the flesh with every strike, causing the body to hemorrhage blood. More effective against larger creatures with more blood than humans.
+  components:
+  - type: Tag
+    tags:
+    - STHunterMachete
+    - Knife
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/combat_knife.rsi
+    state: icon
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    range: 1.3
+    attackRate: 1.1
+    damage:
+      types:
+        Slash: 25
+        Bloodloss: 10
+        #[EN] -- Bloodloss damage is increased against mutants the higher in tier they are; Highest of all for boars.
+  - type: EmbeddableProjectile
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Slash: 25
   - type: Item
     sprite: Objects/Weapons/Melee/combat_knife.rsi
   - type: DisarmMalus

--- a/Resources/Prototypes/_Stalker/ShopPresets/Sidorovich.yml
+++ b/Resources/Prototypes/_Stalker/ShopPresets/Sidorovich.yml
@@ -65,7 +65,9 @@
       priority: 1
       items:
             # Melee
-        StalkerBallBat: 370
+        STKukriKnife: 125 #T1
+        STHuntingMachete: 625 #T2
+          # [EN] -- Hunting Machete purchasable here for live testing, but should be moved to Duty vendor and made craftable with T2 materials after testing.
             # Guns
           # 7mm
         STWeaponShotgunMP155T: 50 #T1

--- a/Resources/Prototypes/_Stalker/ShopPresets/Sidorovich.yml
+++ b/Resources/Prototypes/_Stalker/ShopPresets/Sidorovich.yml
@@ -66,7 +66,7 @@
       items:
             # Melee
         STKukriKnife: 125 #T1
-        STHuntingMachete: 625 #T2
+        STHunterMachete: 625 #T2
           # [EN] -- Hunting Machete purchasable here for live testing, but should be moved to Duty vendor and made craftable with T2 materials after testing.
             # Guns
           # 7mm


### PR DESCRIPTION
<!-- По всем вопросам обращайтесь в наш дискорд https://discord.gg/stalker14 -->

## What I changed
<!-- Напишите что вы изменили или добавьте картинки -->
- First of all, I did some translations of mutant names from Russian to English, added some missing descriptions, and translated others to English. In the case of the 'Hamadryad' the literal translation would have been 'Goblin' and is the only deviation.
- Mutant damage coefficients have been adjusted in the following ways:

1. All mutants no longer have flat slash reduction, and with two exceptions, take increasing damage from bloodloss as their tier increases.
2. T1 mutants now take 3x as much slash damage. This means a Blind Dog will be killed in 2 slashes with a regular combat knife.
3. Boars will 'bleed like stuck pigs' and suffer 1.5x slashing, and 5x bloodloss. Bushes no longer suffer bloodloss damage.
4. T2 mutants have had their bullet resistance reduced from 70% to 25%, take 2.5x slashing damage, and 2x bloodloss.
5. T3 mutants have had their bullet resistance reduced from 70% to 50%, take 1.5x slashing damage, and 3x bloodloss.
6. T4 mutants have had their bullet resistance increased from 70% to 75%, take 1.25x slashing damage, and 4x bloodloss
7. Pseudodogs now have 120 health, same as an alpha blind dog, down from 250.
8. Rats have 10 less health, and no longer do caustic damage.
9. Rodent damage is now all slashing, and increased to 15.
10. T1 boars have 200 health, down from 300. T3 boars have 600 health, up from 450. All boars have had their attack range reduced from 1.5 to 1.15, and the older the boar, the more meat it can drop when butchered.
11. Flesh health reduced from 200 to 150.
12. Lapach has had its damage changed to 5 Piercing, 15 poison, and attack rate reduced by 15%.
13. Hamadryad health reduced from 500 to 300
14. Snork health from 250 to 150, and damage profile reduced from erroneous T3 to T2. Charging damage changed from mostly slashing to mostly blunt.
15. Psy-dog health from 300 to 150, but tier increased from T2 to T3. 
16. Bloodsucker special attack altered. Takes away more blood, but does less bloodloss damage directly, and heals for much less. Base attack no longer deals bloodloss.
17.  Two new melee weapons have been added. The kukri knife is a mostly upgrade from the combat knife, dealing more slashing damage and so being better against low-tier mutants and for general combat than the standard. The Hunter machete is a side-grade that does the same slashing as a knife, but also does 10 bloodloss per hit. This makes it quite deadly against people no matter their armor, but a big damage bonus against higher tier mutants and boars, if you have the balls and the skills to get close without getting beaten to pulp. Currently, both weapons are available from Sidorovich, but the machete may be moved to Duty's vendor after testing.

<!-- Проставить X — [X]: -->
## Please make sure you have checked and agree with the following
- [ ] Yes, I ran my code and tested that the changes work.
- [ ] Yes, I checked that there were no errors in the console output of the client and server after my changes.
- [ ] I agree that by submitting a PR I agree to the terms of the license [License](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [ ] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
