### PR TITLE
Added ammo for mateba

### DIFF
--- a/Resources/Prototypes/_Stalker/ShopPresets/factionsTorgomats/renegats.yml
+++ b/Resources/Prototypes/_Stalker/ShopPresets/factionsTorgomats/renegats.yml
@@ -142,6 +142,9 @@
         45ACPLFMJBox: 100
         45ACPMFMJBox: 250
         45ACPAPBox: 625
+         # .44
+        MagazineBoxRemingtonMagnum: 200
+        MagazineBoxRemingtonMagnumAP: 650
     - name: shop-category-armor
       priority: 4
       items:


### PR DESCRIPTION
There were no ammo for mateba at renegade vendor.