### PR TITLE
Slight Duty Buff

### DIFF
--- a/Resources/Prototypes/_Stalker/ShopPresets/factionsTorgomats/dolg.yml
+++ b/Resources/Prototypes/_Stalker/ShopPresets/factionsTorgomats/dolg.yml
@@ -31,7 +31,7 @@
             # Guns
           # 7mm
         STWeaponShotgunTOZ34: 200
-        STWeaponShotgunMP133: 340 
+        STWeaponShotgunMP133: 340
         STWeaponShotgunMP153: 800
           # 5,45x39
         STWeaponRifleSaiga545: 1000
@@ -44,6 +44,8 @@
           # Other
         WeaponPistolStalkerAPS: 500 #T2
         WeaponPistolStalkerTT: 250
+        STWeaponRifleAH12: 8500
+        STWeaponSniperSVU: 8400
     - name: shop-category-magazines
       priority: 2
       items:
@@ -54,6 +56,7 @@
           # 7,62x54 and 39
         Base739Mag10: 200
         739Mag30: 500
+        754Mag10: 450
           # Smg
         BizonMag: 1100
         VityazMag: 210
@@ -61,6 +64,7 @@
         TTMag: 100
         BaseAPSMag: 150
         PP91Mag: 200
+        AS12Mag: 740
     - name: shop-category-ammunition
       priority: 3
       items:
@@ -85,6 +89,8 @@
         # 7.54
         754FMJBox: 1675
         754HPBox: 1015
+        # Other
+        Ammobox1255TP: 900
 
     - name: shop-category-armor
       priority: 4
@@ -99,6 +105,8 @@
         ClothingOuterArmorRCBZDolg: 1700 # T2 - ENV
         ClothingOuterArmorZaryaDolg: 2000 # T2 - universal
         ClothingOuterArmorSevaDolgRed: 10000 # T3 - ENV
+        ClothingOuterArmorPSZ9D: 23000 # T4 - ENV/PVE
+        STClothingOuterArmorIOTVBlack: 25000 # T4 - PVP
     - name: shop-category-storage-and-containers
       priority: 5
       items:


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
I decided to try to get a buff to duty added.
The reason behind this buff is because on the russian server, Duty use artifacts, but on the EN server they do not. This leads to unfair balancing due to the EN server's Duty not using artifacts, making them weaker than other factions.

I opted to add the ASH-12 along with its respective magazine and T2 Ammo
As well as the SVU sniper rifle and it mag, due to the mosin being removed from the duty shop.
I also chose to add two sets of T4 armor, one being PVP and one being PVE, both at a steep price.


<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
