### PR TITLE
PP1901 + Swamp Ghillie weight down

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Cloak/Capes/T2.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Cloak/Capes/T2.yml
@@ -32,7 +32,7 @@
   description: плотный плащ с нанесённой по верх маскировкой из листьев, травы и палок.
   components:
   - type: STWeight
-    self: 20
+    self: 1.5
   - type: Sprite
     sprite: _Stalker/Objects/Clothing/cloak/bolotniy.rsi
   - type: Clothing

--- a/Resources/Prototypes/_Stalker/ShopPresets/OUTDATED/military.yml
+++ b/Resources/Prototypes/_Stalker/ShopPresets/OUTDATED/military.yml
@@ -545,6 +545,8 @@
         545FMJBox: 25
         545HPBox: 50
         545PCBox: 50
+        725PSTBox: 50
+        725LRNPCBox: 50
         739FMJBox: 50
         739HPBox: 50
         7mmBuckshotBox: 10
@@ -561,6 +563,7 @@
         Magazine762x39RPD: 150
         739Mag30: 150
         754Mag20: 150
+        VityazMag: 150
         Saiga1270Drum: 150
         BaseAPSMag: 75
 
@@ -574,6 +577,7 @@
         STWeaponRifleAKS74: 900
         STWeaponRifleAKS74Green: 900
         STWeaponMachineGunRPD: 1000
+        STWeaponSMGPP1901: 1200
         STWeaponRifleAK103: 1200
         STWeaponShotgunSaiga12: 2500
         STWeaponSniperSVDS: 3000


### PR DESCRIPTION
## What I changed
What this PR does is adds in the PP-1901 to the miltiary as they dont have ANY smgs at all. This makes the ghille suit actually usable instead of 20 kg waiting you roughly down by 100 kg if you even look at it or put it on. 

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
