### PR TITLE
OKSLOP Access for Military Officers.

### DIFF
--- a/Resources/Prototypes/_Stalker/Roles/Jobs/militaries.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/militaries.yml
@@ -144,6 +144,7 @@
         - type: Access
           groups:
             - MilitaryHead
+            - MilitaryStalker
         - type: Bands
           band: Stalker
           bandIcon: army
@@ -185,6 +186,7 @@
         - type: Access
           groups:
             - MilitaryOfficer
+            - MilitaryStalker
         - type: Bands
           band: Stalker
           bandIcon: army


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added Military Stalker access for Military Officers.

Regular Enlisted don't have access.

Reasoning:

They don't fucking play. Military Officers SHOULD have access to bases as well, plus Military can actually get DECENT gear now.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [ ] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
