### PR TITLE
Burer Tweak

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
@@ -71,6 +71,3 @@
     - id: Roubles500
       amount: 1
       prob: 1
-    - id: Dollar100
-      amount: 1
-      prob: 1


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Removed the 100 USD drop from Burer's

Reasoning: Burer's were nerfed back to their OG state. 100 USD each drop for a T3 enemy is easy and farmable. Fucking over Economy atm.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
