### PR TITLE
Artifact Storage 1984

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
@@ -18,6 +18,9 @@
     maxItemSize: Normal
     grid:
     - 0,0,9,9
+    blacklist:
+      tags:
+      - STArtifact
     whitelist:
       components:
         - Material

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Other/SpecialStorages.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Other/SpecialStorages.yml
@@ -16,6 +16,9 @@
     maxItemSize: Normal
     grid:
     - 0,0,4,3
+    blacklist:
+      tags:
+      - STArtifact
   - type: Sprite
     scale: 0.5, 0.5
     sprite: _Stalker/Objects/Devices/Storages/safebreef.rsi


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

# Items Fixed

* Construction Bag

* Protective Case

Items were allowing people to carry artifacts inside them by-passing the 5 artifact buff limit. They had missing blacklist in their code.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
