### PR TITLE
Sp-6 Removal Again....

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Blueprints/Weapon/Ammo/Ammo.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Blueprints/Weapon/Ammo/Ammo.yml
@@ -426,13 +426,13 @@
     - type: STBlueprint
       blueprint: newrecipe939SP5BoxCink
 
-- type: entity
-  parent: STBaseBlueprint
-  id: ST939SP6BoxCinkBlueprint
-  name: Рецепт ящик пуль 9x39 СП-6
-  components:
-    - type: STBlueprint
-      blueprint: newrecipe939SP6BoxCink
+#- type: entity
+#  parent: STBaseBlueprint
+#  id: ST939SP6BoxCinkBlueprint
+#  name: Рецепт ящик пуль 9x39 СП-6
+#  components:
+#    - type: STBlueprint
+#      blueprint: newrecipe939SP6BoxCink
 
 - type: entity
   parent: STBaseBlueprint


### PR DESCRIPTION
## What I changed

* SP-6 BP wasn't removed. It was mislabeled as a T3 ammo when it was actually T4. Was removed from all shops, apparently spawns in caches.... Only costs T2-T3 materials as well to craft. Removing the BP till Shops and Ammos reworked. 

SP6 was voted out ages ago...

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
