### PR TITLE
Admin Test Area Fix

### DIFF
--- a/Resources/Maps/Test/admin_test_arena.yml
+++ b/Resources/Maps/Test/admin_test_arena.yml
@@ -1357,46 +1357,6 @@ entities:
           occludes: False
         back: !type:ContainerSlot
           occludes: False
-- proto: NPCSabbatSerafim
-  entities:
-  - uid: 203
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 104
-    - type: ContainerContainer
-      containers:
-        body_root_part: !type:ContainerSlot {}
-        shoes: !type:ContainerSlot
-          occludes: False
-        jumpsuit: !type:ContainerSlot
-          occludes: False
-        outerClothing: !type:ContainerSlot
-          occludes: False
-        gloves: !type:ContainerSlot
-          occludes: False
-        neck: !type:ContainerSlot
-          occludes: False
-        mask: !type:ContainerSlot
-          occludes: False
-        eyes: !type:ContainerSlot
-          occludes: False
-        ears: !type:ContainerSlot
-          occludes: False
-        head: !type:ContainerSlot
-          occludes: False
-        pocket1: !type:ContainerSlot
-          occludes: False
-        pocket2: !type:ContainerSlot
-          occludes: False
-        suitstorage: !type:ContainerSlot
-          occludes: False
-        id: !type:ContainerSlot
-          occludes: False
-        belt: !type:ContainerSlot
-          occludes: False
-        back: !type:ContainerSlot
-          occludes: False
 - proto: NPCSidorovich
   entities:
   - uid: 209


### PR DESCRIPTION
## What I changed

Fixed admin area

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed the Sabbat Serafim NPC from the admin test arena map, including all related entities and container data.
  * The removed NPC will no longer spawn or be interactable in that map.
  * Loot/containers tied to this NPC in that map have been removed.
  * Change is limited to the admin test arena; other NPCs and areas are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->