### PR TITLE
Burden nerf (Fixed)

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/gravity.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/gravity.yml
@@ -335,7 +335,7 @@
     - type: ZoneAnomalyEffectAddComponent
       components:
       - type: ZoneAnomalyWeightModifier
-        multiply: 2
+        multiply: 1.5
     - type: ZoneAnomaly
       detectedLevel: 3
     - type: Fixtures


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Burden anomalies now multiply your weight by 1.5 instead of 2. That's it.

With artifact containers now having 3kgs of weight, the standard artifact hunting Rookie kit ends up being around 90kgs. Just picking up two artifacts or a few boar hoofs puts them at 100kgs, bringing them to a complete stop at Burdens... This isn't really difficult, challenging, or engaging in any way, just very annoying. They'll only effectively be able to counter Burdens after getting a better detector and being able to find Amoebas up north. With this change, the Burdens will only completely stop you at 135kgs.

Didn't test the code, but it's a one number change, so _probably_ nothing should break.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [ ] Yes, I ran my code and tested that the changes worked
- [ ] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
