### PR TITLE
fix(st-pack-spawner): use TriggerEvent instead of immediate spawn on placement

### DIFF
--- a/Content.Server/_Stalker/Pack/STPackSpawnerComponent.cs
+++ b/Content.Server/_Stalker/Pack/STPackSpawnerComponent.cs
@@ -1,11 +1,35 @@
-﻿using Content.Shared._Stalker.Pack;
+using Content.Shared._Stalker.Pack;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._Stalker.Pack;
 
-[RegisterComponent]
+[RegisterComponent, AutoGenerateComponentPause]
+[Access(typeof(STPackSystem))]
 public sealed partial class STPackSpawnerComponent : Component
 {
     [DataField]
     public ProtoId<STPackPrototype> ProtoId;
+
+    /// <summary>
+    /// Chance of spawning a pack when triggered (0-1).
+    /// </summary>
+    [DataField]
+    public float Chance = 1.0f;
+
+    /// <summary>
+    /// Cooldown in seconds before trigger can fire again.
+    /// </summary>
+    [DataField]
+    public float Cooldown = 600f;
+
+    /// <summary>
+    /// Time when cooldown expires and trigger can fire again.
+    /// </summary>
+    [AutoPausedField]
+    public TimeSpan? CooldownTime;
+
+    /// <summary>
+    /// Whether this spawner is currently enabled.
+    /// </summary>
+    public bool Enabled = true;
 }

--- a/Resources/Prototypes/_Stalker/SpawnersNTriggers/Mobs/packspawners.yml
+++ b/Resources/Prototypes/_Stalker/SpawnersNTriggers/Mobs/packspawners.yml
@@ -6,6 +6,8 @@
   components:
     - type: STPackSpawner
       protoId: STBlindDogPack
+      chance: 1.0
+      cooldown: 600
     - type: ApproachTrigger
     - type: Sprite
       layers:
@@ -22,6 +24,8 @@
   components:
     - type: STPackSpawner
       protoId: STSpiderLapachPack
+      chance: 1.0
+      cooldown: 600
     - type: ApproachTrigger
     - type: Sprite
       layers:
@@ -38,6 +42,8 @@
   components:
     - type: STPackSpawner
       protoId: STControllerBlindDogPack
+      chance: 1.0
+      cooldown: 600
     - type: ApproachTrigger
     - type: Sprite
       layers:

--- a/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/Mobs/packspawners.yml
+++ b/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/Mobs/packspawners.yml
@@ -6,6 +6,8 @@
   components:
   - type: STPackSpawner
     protoId: STBearFamilyPack
+    chance: 1.0
+    cooldown: 600
   - type: ApproachTrigger
   - type: Sprite
     layers:


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
- Pack spawners now spawn on player approach (via TriggerEvent) instead of immediately on placement
- Added cooldown system (default 10 minutes) to prevent spam spawning
- Added configurable `chance` and `cooldown` fields to STPackSpawnerComponent
- Fixed pre-existing bug: replaced non-existent `DeleteComponent` with `EntityTerminatingEvent`

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
