### PR TITLE
fix(client): resolve typing indicator RSI state mismatch error

### DIFF
--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorVisualizerSystem.cs
@@ -36,9 +36,11 @@ public sealed class TypingIndicatorVisualizerSystem : VisualizerSystem<TypingInd
         }
 
         AppearanceSystem.TryGetData<bool>(uid, TypingIndicatorVisuals.IsTyping, out var isTyping, args.Component);
-        var layerExists = args.Sprite.LayerMapTryGet(TypingIndicatorLayers.Base, out var layer);
-        if (!layerExists)
-            layer = args.Sprite.LayerMapReserveBlank(TypingIndicatorLayers.Base);
+
+        if (args.Sprite.LayerMapTryGet(TypingIndicatorLayers.Base, out var existingLayer))
+            args.Sprite.RemoveLayer(existingLayer);
+
+        var layer = args.Sprite.LayerMapReserveBlank(TypingIndicatorLayers.Base);
 
         args.Sprite.LayerSetRSI(layer, proto.SpritePath);
         args.Sprite.LayerSetState(layer, proto.TypingState);


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
When equipping faction dogtags after the typing indicator layer was already initialized with a different RSI, the sprite layer retained the old state which didn't exist in the new RSI, causing errors.

Fix by recreating the layer fresh on each appearance change instead of reusing an existing layer with potentially incompatible state.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
