### PR TITLE
fix(chat): typing indicator not showing faction after respawn

### DIFF
--- a/Content.Shared/Chat/TypingIndicator/SharedTypingIndicatorSystem.cs
+++ b/Content.Shared/Chat/TypingIndicator/SharedTypingIndicatorSystem.cs
@@ -51,11 +51,13 @@ public abstract class SharedTypingIndicatorSystem : EntitySystem
     private void OnGotEquipped(Entity<TypingIndicatorClothingComponent> entity, ref ClothingGotEquippedEvent args)
     {
         entity.Comp.GotEquippedTime = _timing.CurTime;
+        Dirty(entity);
     }
 
     private void OnGotUnequipped(Entity<TypingIndicatorClothingComponent> entity, ref ClothingGotUnequippedEvent args)
     {
         entity.Comp.GotEquippedTime = null;
+        Dirty(entity);
     }
 
     private void BeforeShow(Entity<TypingIndicatorClothingComponent> entity, ref InventoryRelayedEvent<BeforeShowTypingIndicatorEvent> args)

--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorClothingComponent.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorClothingComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.Chat.TypingIndicator;
 ///     If an item is equipped to someones inventory (Anything but the pockets), and has this component
 ///     the users typing indicator will be replaced by the prototype given in <c>TypingIndicatorPrototype</c>.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause, AutoGenerateComponentState]
 [Access(typeof(SharedTypingIndicatorSystem))]
 public sealed partial class TypingIndicatorClothingComponent : Component
 {
@@ -23,6 +23,6 @@ public sealed partial class TypingIndicatorClothingComponent : Component
     /// <summary>
     ///     This stores the time the item was equipped in someones inventory. If null, item is currently not equipped.
     /// </summary>
-    [DataField, AutoPausedField]
+    [DataField, AutoPausedField, AutoNetworkedField]
     public TimeSpan? GotEquippedTime = null;
 }


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->
 
## What I changed
<!-- Write what you changed or add pictures -->
 - Fixed bug where typing indicator showed default style instead of faction style after respawn
 - Added network synchronization for `TypingIndicatorClothingComponent.GotEquippedTime` field
 
<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
