### PR TITLE
fix(anomaly): correct glass shards icon state typo for anomaly vision

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Anomalies/gravity.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Anomalies/gravity.yml
@@ -98,4 +98,4 @@
   - type: STAnomalyTips
     icon:
       sprite: /Textures/_Stalker/Interface/Overlays/anomaly_tips.rsi
-      state: gravi
+      state: gravity


### PR DESCRIPTION
## What I changed

  Fixed the glass shards anomaly not appearing in Monolith faction's anomaly vision.

  **Root cause:** Typo in icon state - `gravi` instead of `gravity` in `Resources/Prototypes/_Stalker_EN/Entities/Objects/Anomalies/gravity.yml`

  The `anomaly_tips.rsi` sprite file only contains: `unknown`, `electric`, `fiery`, `gravity`, `icy`, `toxic` - the state `gravi` doesn't exist, so the overlay couldn't render the icon.

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
