### PR TITLE
fix: re-enable SSD indicator for disconnected players

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -173,7 +173,7 @@
       types:
         Blunt: 5
   - type: SleepEmitSound
-#  - type: SSDIndicator # stalker-changes
+  - type: SSDIndicator
   - type: StandingState
   - type: Dna
   - type: MindContainer


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->                   
                                                                                                                 
  ## What I changed                                                                                              
  Re-enabled the SSD (Soul-less, Soulless, or Disconnected) indicator for players who disconnect from the game.  
                                                                                                                 
  <img width="143" height="144" alt="image"                                                                      
  src="https://github.com/user-attachments/assets/8c630608-3f05-49a1-aa0f-9a5e69d68b30" />                        
                                                                                                                 
  <!-- Put X — [X]: -->                                                                                          
  ## Make sure you check and agree to the following                                                              
  - [X] Yes, I ran my code and tested that the changes worked                                                    
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes 
  - [X] I agree that by submitting a PR I agree to the terms of the                                              
  [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).                            
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or   
  are under an open license