### PR TITLE
fix(storage): move CartridgeAmmo from tags to components in whitelist

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/RPC.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/RPC.yml
@@ -74,8 +74,9 @@
       grid:
         - 0,0,7,7
       whitelist:
-        tags:
+        components:
           - CartridgeAmmo
+        tags:
           - Cartridge
 
 - type: entity


### PR DESCRIPTION
## What I changed                                                                                                                                                                                                                          
                                                                                                                                                                                                                                             
  Fixed cartridges not being storable in bandoliers.                                                                                                                                                                                         
                                                                                                                                                                                                                                             
  **Problem:** Cartridges could not be stored in the bandolier belt despite being the intended storage item.                                                                                                                                 
                                                                                                                                                                                                                                             
  **Root Cause:** The bandolier's storage whitelist was checking for `CartridgeAmmo` as a **tag**, but cartridge entities have `CartridgeAmmo` as a **component**.                                                                           
                                                                                                                                                                                                                                             
  **Solution:** Updated the whitelist in `RPC.yml` to check for `CartridgeAmmo` in `components` instead of `tags`.                                                                                                                           
                                                                                                                                                                                                                                             
  ## Make sure you check and agree to the following                                                                                                                                                                                          
  - [X] Yes, I ran my code and tested that the changes worked                                                                                                                                                                                
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes                                                                                                                             
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).                                                                                      
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license 