### PR TITLE
fix(storage): prevent mixed ammo type loss during stash storage/retrieval

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -41,9 +41,9 @@ public sealed partial class GunSystem
         else if (component.UnspawnedCount > 0)
         {
             component.UnspawnedCount--;
-            var copy = component.EntProtos; // stalker-changes-start
-            copy.Reverse();
-            var proto = copy.FirstOrNull();
+            var proto = component.EntProtos.Count > 0 // stalker-changes-start
+                ? (Robust.Shared.Prototypes.EntProtoId?)component.EntProtos[^1]
+                : null;
             if (proto != null)
             {
                 ent = Spawn(proto.Value, coordinates);

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -23,9 +23,9 @@ public sealed partial class GunSystem
         }
         else if (component.UnspawnedCount > 0)
         {
-            var copy = component.EntProtos; // stalker-changes-start
-            copy.Reverse();
-            var proto = copy.FirstOrNull();
+            var proto = component.EntProtos.Count > 0 // stalker-changes-start
+                ? (Robust.Shared.Prototypes.EntProtoId?)component.EntProtos[^1]
+                : null;
             if (proto != null)
             {
                 ent = Spawn(proto.Value, coordinates);

--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -319,6 +319,9 @@ public sealed class StalkerRepositorySystem : EntitySystem
         _stalkerStorageSystem.SaveStorage(component);
         RaiseLocalEvent(args.User, new RepositoryItemInjectedEvent(args.Target, itemInfo));
 
+        // Mark as handled BEFORE deletion - prevents interaction system from continuing with deleted entity
+        args.Handled = true;
+
         // removing by hashset we got from above
         // i had to move it here because of references
         if (toDelete == null)

--- a/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
+++ b/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
@@ -228,13 +228,36 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
 
         if (!TryComp(inputItem, out BallisticAmmoProviderComponent? ammoProvider))
             return returnList;
+
+        // Set Proto from first contained entity if not already set
         if (ammoProvider.Container.ContainedEntities.Count != 0)
         {
             var ent = ammoProvider.Container.ContainedEntities.First();
             var entProto = GetPrototypeName(ent);
             ammoProvider.Proto ??= entProto;
         }
-        returnList.Add(new AmmoContainerStalker(GetPrototypeName(inputItem), ammoProvider.Proto, ammoProvider.EntProtos, ammoProvider.Count));
+
+        // Convert EntProtoId list to strings for JSON serialization compatibility.
+        // EntProtoId is a readonly record struct that System.Text.Json cannot reliably deserialize.
+        var completeEntProtos = ammoProvider.EntProtos.Select(e => (string)e).ToList();
+
+        // Pad with default Proto for any unspawned ammo not yet tracked in EntProtos.
+        // Inserted at beginning because unspawned ammo is oldest and used last (LIFO order).
+        var untracked = ammoProvider.Count - completeEntProtos.Count;
+        if (untracked > 0 && ammoProvider.Proto != null)
+        {
+            for (var i = 0; i < untracked; i++)
+            {
+                completeEntProtos.Insert(0, (string)ammoProvider.Proto.Value);
+            }
+        }
+
+        returnList.Add(new AmmoContainerStalker(
+            GetPrototypeName(inputItem),
+            ammoProvider.Proto,
+            completeEntProtos,
+            ammoProvider.Count));
+
         return returnList;
     }
 
@@ -327,9 +350,13 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
         }
     }
 
-    private List<EntProtoId> MapPrototype(in List<EntProtoId> protoIds)
+    /// <summary>
+    /// Maps a list of prototype IDs through the prototype mapping table.
+    /// Used to handle prototype ID changes between game versions.
+    /// </summary>
+    private List<string> MapPrototype(in List<string> protoIds)
     {
-        return protoIds.Select(MapPrototype).ToList();
+        return protoIds.Select(id => (string)MapPrototype((EntProtoId)id)).ToList();
     }
 
     private EntProtoId MapPrototype(EntProtoId protoId)
@@ -386,7 +413,8 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
                 {
                     ammoProvider.Proto = options.AmmoPrototypeName;
                     ammoProvider.UnspawnedCount = options.AmmoCount;
-                    ammoProvider.EntProtos = options.EntProtoIds;
+                    // Convert strings back to EntProtoId for the component
+                    ammoProvider.EntProtos = options.EntProtoIds.Select(s => (EntProtoId)s).ToList();
                     Dirty(inputItemUid, ammoProvider);
                 }
                 break;
@@ -774,7 +802,38 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
                         playerInventory.AllItems.Add(newObject);
                     break;
                 case "AmmoContainerStalker":
-                    newObject = node.Deserialize<AmmoContainerStalker>();
+                    // Manual parsing required for backward compatibility with existing database entries.
+                    // Old format serialized EntProtoIds as [{"Id":"..."}] (EntProtoId objects).
+                    // New format serializes as ["..."] (plain strings).
+                    // This handles both formats to preserve existing player stash data.
+                    var protoName = node["PrototypeName"]?.GetValue<string>() ?? "";
+                    var ammoProtoName = node["AmmoPrototypeName"]?.GetValue<string>();
+                    var ammoCount = node["AmmoCount"]?.GetValue<int>() ?? 0;
+                    var countVending = node["CountVendingMachine"]?.GetValue<uint>() ?? 1;
+
+                    var entProtoIds = new List<string>();
+                    var entProtoIdsNode = node["EntProtoIds"]?.AsArray();
+                    if (entProtoIdsNode != null)
+                    {
+                        foreach (var item in entProtoIdsNode)
+                        {
+                            if (item == null)
+                                continue;
+
+                            // Old format: {"Id": "..."} - extract the Id property
+                            if (item is JsonObject obj && obj["Id"] != null)
+                            {
+                                entProtoIds.Add(obj["Id"]!.GetValue<string>());
+                            }
+                            // New format: "..." - use value directly
+                            else
+                            {
+                                entProtoIds.Add(item.GetValue<string>());
+                            }
+                        }
+                    }
+
+                    newObject = new AmmoContainerStalker(protoName, ammoProtoName, entProtoIds, ammoCount, countVending);
                     if (newObject != null)
                         playerInventory.AllItems.Add(newObject);
                     break;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -262,9 +262,9 @@ public abstract partial class SharedGunSystem
             }
             else if (component.UnspawnedCount > 0)
             { // stalker-changes-start
-                var copy = component.EntProtos;
-                copy.Reverse();
-                var proto = copy.FirstOrNull();
+                var proto = component.EntProtos.Count > 0
+                    ? (Robust.Shared.Prototypes.EntProtoId?)component.EntProtos[^1]
+                    : null;
                 if (proto != null)
                 {
                     entity = Spawn(proto.Value, args.Coordinates);


### PR DESCRIPTION
## What I changed                                                                                          
                                                                                                             
  Fixed mixed ammo type loss when storing and retrieving magazines from the personal stash.                  
                                                                                                             
  **Problem:** When a magazine containing two different ammo types (e.g., AP and standard rounds) was stored 
  in the stash and retrieved, only one ammo type was present - the other was lost.                           
                                                                                                             
  **Root Cause:** `EntProtoId` is a `readonly record struct` that `System.Text.Json` cannot reliably         
  deserialize without custom converters. The `List<EntProtoId>` in `AmmoContainerStalker` was being corrupted
   during JSON round-trip.                                                                                   
                                                                                                             
  **Solution:**                                                                                              
  - Changed `EntProtoIds` from `List<EntProtoId>` to `List<string>` for reliable JSON serialization          
  - Added backward-compatible JSON parsing to support existing database entries (both old `[{"Id":"..."}]`   
  and new `["..."]` formats)                                                                                 
  - Fixed inefficient `list.Reverse()` pattern in `GunSystem.Ballistic` using `[^1]` index-from-end syntax   
  - Fixed interaction handling order in `StalkerRepositorySystem` (set `args.Handled` before entity deletion)                             
                                                                                                             
  ## Make sure you check and agree to the following                                                          
  - [X] Yes, I ran my code and tested that the changes worked                                                
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my     
  changes                                                                                                    
  - [X] I agree that by submitting a PR I agree to the terms of the                                          
  [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).                        
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me  
  or are under an open license 