### PR TITLE
feat(shop):  add health analyzer items to ecologist

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -76,7 +76,6 @@
         MedkitScience: 175
         MedkitMilitary: 100
         Defibrillator: 700
-        HandheldHealthAnalyzer: 300
         MedkitElite: 500
         MedkitLAR: 650
         # Crates
@@ -187,7 +186,7 @@
         ClothingBackpackDuffelGreenStalkerHydroponic: 500
         Beaker: 40
         Syringe: 20
-        MedTekCartridge: 150
+        MedTekCartridge: 1500
         LargeBeaker: 50
         BaseChemistryEmptyVial: 40
         ClothingGoPro: 250


### PR DESCRIPTION
## What I changed

Added medical diagnostic equipment to the ecologist faction shop (`NpcResearchInstituteEN` - Prof. Round):
  - **MedTekCartridge** (1500₽) - Added to Utilities category

This allows players to purchase health analyzers for radiation readings and medical diagnostics without needing to 
  attack ecologists.                       

  ## Make sure you check and agree to the following                                                                  
  - [X] Yes, I ran my code and tested that the changes worked                                                        
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes     
  - [X] I agree that by submitting a PR I agree to the terms of the                                                  
  [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).                                
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are   
  under an open license