### PR TITLE
fix(svarog): fix radar breaking bug and reduce beep range

### DIFF
--- a/Content.Client/_Stalker_EN/Devices/Radar/UI/RadarControl.cs
+++ b/Content.Client/_Stalker_EN/Devices/Radar/UI/RadarControl.cs
@@ -32,7 +32,7 @@ public sealed class RadarControl : Control
     private const float SweepHitThreshold = 0.15f; // Radians tolerance for sweep detection
 
     private float _lastSweepAngle;
-    private float _sweepStartTime;
+    private float _sweepStartTime = -1f;  // Sentinel for uninitialized
 
     // Struct to hold revealed blip state (position at time of reveal)
     private struct RevealedBlip
@@ -87,8 +87,8 @@ public sealed class RadarControl : Control
             return;
         }
 
-        // If scanner just turned on, reset sweep to start from top (0 radians)
-        if (!_scannerEnabled && scannerEnabled)
+        // If scanner just turned on OR sweep time uninitialized, reset sweep to start from top (0 radians)
+        if ((!_scannerEnabled && scannerEnabled) || _sweepStartTime < 0)
         {
             _sweepStartTime = (float)_timing.CurTime.TotalSeconds;
             _lastSweepAngle = 0f; // Start at top

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
@@ -25,7 +25,7 @@
   # Anomaly detection (audio beeping) - kept for beeping functionality
   - type: ZoneAnomalyDetector
     level: 5
-    distance: 18
+    distance: 7
     maxBeepInterval: 1
     minBeepInterval: 0.01
     beepSound: /Audio/_Stalker/Items/Detectors/Anomaly/da_beep3.ogg


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

- Fixed a bug in `RadarControl.cs` where the sweep start time was uninitialized, causing the radar to break when first opened
- Added sentinel value (-1) initialization for `_sweepStartTime` and added a check to properly reset the sweep when the time is uninitialized
- Reduced the Svarog detector beep range from 18 to 7 to make anomaly detection more balanced

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @teecoding

- fix: Fixed Svarog radar UI breaking when first opened
- tweak: Reduced Svarog anomaly beep detection range from 18 to 7

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [ ] Yes, I ran my code and tested that the changes worked
- [ ] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [ ] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [ ] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license