### PR TITLE
fix(weapons): prevent suppressor volume accumulation and scope action bug

### DIFF
--- a/Content.Server/_DZ/FarGunshot/FarGunshotComponent.cs
+++ b/Content.Server/_DZ/FarGunshot/FarGunshotComponent.cs
@@ -24,5 +24,9 @@ public sealed partial class FarGunshotComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float SilencerDecrease = 1f;
 
-    // TODO: silencer impl
+    /// <summary>
+    /// The base volume of the far gunshot sound before any modifications.
+    /// </summary>
+    [DataField]
+    public float BaseVolume;
 }

--- a/Content.Server/_DZ/FarGunshot/FarGunshotSystem.cs
+++ b/Content.Server/_DZ/FarGunshot/FarGunshotSystem.cs
@@ -52,7 +52,7 @@ public sealed class FarGunshotSystem : EntitySystem
             component.Sound,
             farSoundFilter,
             recordReplay: true,
-            AudioParams.Default
+            component.Sound?.Params ?? AudioParams.Default
         );
     }
 

--- a/Content.Server/_Stalker/Weapon/Module/STWeaponModuleSystem.cs
+++ b/Content.Server/_Stalker/Weapon/Module/STWeaponModuleSystem.cs
@@ -74,22 +74,17 @@ public sealed class STWeaponModuleSystem : STSharedWeaponModuleSystem
         {
             farGunshotComponent.SilencerDecrease = effect.FarshotSoundDecrease;
 
-            var farAudioParams = farGunshotComponent.Sound.Params;
-
-            farAudioParams.Volume += effect.SoundGunshotVolumeAddition;
-            farGunshotComponent.Sound.Params = farAudioParams;
+            // Use WithVolume() to SET from base, not accumulate
+            farGunshotComponent.Sound.Params = farGunshotComponent.Sound.Params
+                .WithVolume(farGunshotComponent.BaseVolume + effect.SoundGunshotVolumeAddition);
         }
 
         if (args.SoundGunshot is null)
             return;
 
-        var audioParams = args.SoundGunshot?.Params ?? AudioParams.Default;
-
-        // Hotfix how to handle super silent silencers happening because volume additions
-        // pile up. We need to find something else, because a user in the future might have
-        // not only one volume reducing module
-        audioParams.Volume += effect.SoundGunshotVolumeAddition;
-        args.SoundGunshot!.Params = audioParams;
+        // Use WithVolume() to SET from AudioParams.Default.Volume (0), not accumulate
+        args.SoundGunshot.Params = args.SoundGunshot.Params
+            .WithVolume(AudioParams.Default.Volume + effect.SoundGunshotVolumeAddition);
     }
 
     private void UpdateContainerEffect(BaseContainer container)


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

### Suppressor Volume Fix
Fixed an issue where attaching and detaching silencers would cause gunshot volume to accumulate incorrectly. The volume would get quieter each time you reattached a suppressor because the code was using `+=` on a reference type instead of computing fresh values.

**Before:** Attach silencer (-8dB) → Remove → Attach again = -16dB (broken)
**After:** Attach silencer (-8dB) → Remove → Attach again = -8dB (correct)

The fix uses `WithVolume()` to set absolute values from a stored base volume rather than accumulating.

### Far Gunshot Sound Fix
Fixed far gunshot sounds (heard by distant players) ignoring suppressor volume modifications. Added `BaseVolume` field to `FarGunshotComponent` to track the original volume.

### Scope Action Fix
Fixed scope action icon not appearing when dynamically attaching a scope module to a weapon:
- Action is now created immediately when scope component is added dynamically (MapInitEvent doesn't fire for existing entities)
- Action is granted to the holder if the weapon is already being held
- Action entity is properly deleted when scope component is removed, preventing orphaned actions that caused issues on reattach

## Changelog

author: @teecoding

- fix: Suppressor no longer makes guns progressively quieter when reattached multiple times
- fix: Distant players now hear suppressed gunshots at the correct reduced volume
- fix: Scope action icon now appears immediately when attaching a scope module to a held weapon

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
