### PR TITLE
fix(stash): add missing detector category to Veles and Svarog

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
@@ -5,6 +5,8 @@
   description: An advanced detection device combining artifact radar with anomaly detection. The upgraded version of Veles.
   suffix: Stalker EN, Advanced Radar
   components:
+  - type: RepositoryItem
+    categoryName: repository-detectors-category
   - type: Sprite
     sprite: _Stalker_EN/Objects/Devices/svarog.rsi
     layers:

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/veles.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/veles.yml
@@ -7,6 +7,8 @@
   components:
   - type: Item
     size: Normal
+  - type: RepositoryItem
+    categoryName: repository-detectors-category
   - type: Sprite
     sprite: _Stalker_EN/Objects/Devices/veles.rsi
     layers:


### PR DESCRIPTION
## What I changed

Added the `RepositoryItem` component with `repository-detectors-category` to both Veles and Svarog devices so they now appear under the "Detectors" category in the personal stash.

## Changelog

author: @teecoding

- fix: Veles and Svarog now appear in the Detectors category in personal stash

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
