### PR TITLE
feat(weather): add weather scheduler system for automatic weather cycling

### DIFF
--- a/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleComponent.cs
+++ b/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleComponent.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Destructible.Thresholds;
+using Content.Shared.Weather;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Stalker_EN.Weather;
+
+[RegisterComponent, Access(typeof(WeatherSchedulerRuleSystem))]
+public sealed partial class WeatherSchedulerRuleComponent : Component
+{
+    /// <summary>
+    /// Weighted pool of weather prototypes. Higher weight = more likely.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<ProtoId<WeatherPrototype>, float> WeatherPool = new();
+
+    /// <summary>
+    /// Weight for clear weather (no weather effect).
+    /// </summary>
+    [DataField]
+    public float ClearWeatherWeight = 1.0f;
+
+    /// <summary>
+    /// Min/max seconds between weather changes.
+    /// </summary>
+    [DataField]
+    public MinMax ChangeInterval = new(600, 1800);
+
+    /// <summary>
+    /// Min/max duration in seconds for each weather effect.
+    /// </summary>
+    [DataField]
+    public MinMax WeatherDuration = new(300, 900);
+
+    /// <summary>
+    /// Whether to pause scheduling during active emissions.
+    /// </summary>
+    [DataField]
+    public bool PauseDuringEmission = true;
+
+    // Runtime state (not serialized)
+    public TimeSpan NextWeatherChangeTime;
+    public ProtoId<WeatherPrototype>? CurrentWeather;
+    public bool WaitingForEmission;
+}

--- a/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleSystem.cs
+++ b/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleSystem.cs
@@ -1,0 +1,100 @@
+using Content.Server._Stalker_EN.Emission;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Weather;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Stalker_EN.Weather;
+
+public sealed class WeatherSchedulerRuleSystem : GameRuleSystem<WeatherSchedulerRuleComponent>
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedWeatherSystem _weather = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+
+    protected override void Started(EntityUid uid, WeatherSchedulerRuleComponent component,
+        GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+        var initialDelay = component.ChangeInterval.Next(_random);
+        component.NextWeatherChangeTime = _timing.CurTime + TimeSpan.FromSeconds(initialDelay);
+    }
+
+    protected override void ActiveTick(EntityUid uid, WeatherSchedulerRuleComponent component,
+        GameRuleComponent gameRule, float frameTime)
+    {
+        base.ActiveTick(uid, component, gameRule, frameTime);
+
+        if (component.PauseDuringEmission && IsEmissionActive())
+        {
+            component.WaitingForEmission = true;
+            return;
+        }
+
+        if (component.WaitingForEmission)
+        {
+            component.WaitingForEmission = false;
+            component.NextWeatherChangeTime = _timing.CurTime + TimeSpan.FromSeconds(60);
+            return;
+        }
+
+        if (_timing.CurTime < component.NextWeatherChangeTime)
+            return;
+
+        ChangeWeather(component);
+        var nextInterval = component.ChangeInterval.Next(_random);
+        component.NextWeatherChangeTime = _timing.CurTime + TimeSpan.FromSeconds(nextInterval);
+    }
+
+    private void ChangeWeather(WeatherSchedulerRuleComponent component)
+    {
+        var selectedWeather = PickWeather(component);
+        var duration = component.WeatherDuration.Next(_random);
+        var endTime = _timing.CurTime + TimeSpan.FromSeconds(duration);
+
+        component.CurrentWeather = selectedWeather;
+
+        WeatherPrototype? weatherProto = null;
+        if (selectedWeather.HasValue)
+            weatherProto = _protoManager.Index(selectedWeather.Value);
+
+        var query = EntityQueryEnumerator<MapComponent>();
+        while (query.MoveNext(out _, out var mapComp))
+        {
+            _weather.SetWeather(mapComp.MapId, weatherProto, endTime);
+        }
+    }
+
+    private ProtoId<WeatherPrototype>? PickWeather(WeatherSchedulerRuleComponent component)
+    {
+        var totalWeight = component.ClearWeatherWeight;
+        foreach (var weight in component.WeatherPool.Values)
+            totalWeight += weight;
+
+        var rand = _random.NextFloat() * totalWeight;
+        var accumulated = component.ClearWeatherWeight;
+
+        if (rand < accumulated)
+            return null;
+
+        foreach (var (weatherId, weight) in component.WeatherPool)
+        {
+            accumulated += weight;
+            if (rand < accumulated)
+                return weatherId;
+        }
+
+        return null;
+    }
+
+    private bool IsEmissionActive()
+    {
+        var query = EntityQueryEnumerator<EmissionEventRuleComponent, ActiveGameRuleComponent>();
+        return query.MoveNext(out _, out _, out _);
+    }
+}

--- a/Resources/Prototypes/_Stalker/game_presets.yml
+++ b/Resources/Prototypes/_Stalker/game_presets.yml
@@ -6,4 +6,5 @@
   description: game-preset-stalker-description
   rules:
     - STEmissionEventScheduler
+    - STWeatherScheduler
   supportedMaps: STDefaultMapPool

--- a/Resources/Prototypes/_Stalker_EN/GameRules/weather_scheduler.yml
+++ b/Resources/Prototypes/_Stalker_EN/GameRules/weather_scheduler.yml
@@ -1,0 +1,20 @@
+- type: entity
+  id: STWeatherScheduler
+  parent: BaseGameRule
+  components:
+  - type: WeatherSchedulerRule
+    weatherPool:
+      Rain: 3.0
+      Storm: 1.0
+      STFogLight: 2.5
+      STFogHeavy: 1.0
+      SnowfallLight: 1.5
+      SnowfallMedium: 1.0
+    clearWeatherWeight: 4.0
+    changeInterval:
+      min: 600
+      max: 1800
+    weatherDuration:
+      min: 300
+      max: 900
+    pauseDuringEmission: true


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added an independent weather scheduler system that automatically cycles through weather types on Stalker maps.

**Features:**
- Weighted random weather selection (Rain, Storm, Fog, Snow, etc.)
- Configurable clear weather periods between effects
- Randomized intervals between weather changes (10-30 min default)
- Randomized weather duration (5-15 min default)
- Automatically pauses during emissions to avoid conflicts with emission rain
- Resumes 60 seconds after emission ends

## Changelog

author: @teecoding

- add: Automatic weather cycling system with rain, storms, fog, and snow

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
