### PR TITLE
fix(anomalies): increase idle visibility for Gravi and Grabber anomalies

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/gravity.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/gravity.yml
@@ -27,7 +27,7 @@
       gradient: Linear
     - type: Stealth
     - type: ZoneAnomalyEffectStealth
-      idle: -0.3
+      idle: 0.2
       activated: 1
     - type: ZoneAnomaly
       detectedLevel: 1
@@ -85,7 +85,7 @@
       gradient: Linear
     - type: Stealth
     - type: ZoneAnomalyEffectStealth
-      idle: -0.3
+      idle: 0.2
       activated: 1
     - type: ZoneAnomaly
       detectedLevel: 2


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Updated idle visibility for Gravi and Grabber gravity anomalies from `-0.3` to `0.2` to match the Vortex anomaly's visibility level. This makes these anomalies slightly visible (20% opacity) when idle instead of being nearly invisible.

## Changelog
author: @teecoding

- tweak: Gravi and Grabber anomalies are now slightly visible when idle, matching Vortex anomaly visibility

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
