### PR TITLE
fix(ci): add write permissions to changelog workflow and remove test branch from validation

### DIFF
--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -3,7 +3,7 @@ name: Validate Changelog
 on:
   pull_request:
     types: [opened, edited, synchronize]
-    branches: [master, test]
+    branches: [master]
 
 jobs:
   validate-changelog:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [master]
 
+permissions:
+  contents: write
+
 jobs:
   update-changelog:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

- Added `permissions: contents: write` to the changelog workflow so the GitHub Actions bot can push changelog commits
- Removed `test` branch from changelog validation triggers (only runs on `master` now)

## Changelog

author: @teecoding

- fix: Changelog auto-generation now works correctly on PR merge

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
