### PR TITLE
feat(chat): add narration channel for admin/GM scene descriptions

### DIFF
--- a/Content.Client/Chat/Managers/ChatManager.cs
+++ b/Content.Client/Chat/Managers/ChatManager.cs
@@ -77,6 +77,10 @@ internal sealed class ChatManager : IChatManager
                 _consoleHost.ExecuteCommand($"whisper \"{CommandParsing.Escape(str)}\"");
                 break;
 
+            case ChatSelectChannel.Narration:
+                _consoleHost.ExecuteCommand($"narrate \"{CommandParsing.Escape(str)}\"");
+                break;
+
             default:
                 throw new ArgumentOutOfRangeException(nameof(channel), channel, null);
         }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -84,7 +84,8 @@ public sealed class ChatUIController : UIController
         {SharedChatSystem.EmotesAltPrefix, ChatSelectChannel.Emotes},
         {SharedChatSystem.AdminPrefix, ChatSelectChannel.Admin},
         {SharedChatSystem.RadioCommonPrefix, ChatSelectChannel.Radio},
-        {SharedChatSystem.DeadPrefix, ChatSelectChannel.Dead}
+        {SharedChatSystem.DeadPrefix, ChatSelectChannel.Dead},
+        {SharedChatSystem.NarrationPrefix, ChatSelectChannel.Narration}
     };
 
     public static readonly Dictionary<ChatSelectChannel, char> ChannelPrefixes = new()
@@ -97,7 +98,8 @@ public sealed class ChatUIController : UIController
         {ChatSelectChannel.Emotes, SharedChatSystem.EmotesPrefix},
         {ChatSelectChannel.Admin, SharedChatSystem.AdminPrefix},
         {ChatSelectChannel.Radio, SharedChatSystem.RadioCommonPrefix},
-        {ChatSelectChannel.Dead, SharedChatSystem.DeadPrefix}
+        {ChatSelectChannel.Dead, SharedChatSystem.DeadPrefix},
+        {ChatSelectChannel.Narration, SharedChatSystem.NarrationPrefix}
     };
 
     /// <summary>
@@ -525,12 +527,13 @@ public sealed class ChatUIController : UIController
 
         if (_state.CurrentState is GameplayStateBase)
         {
-            // can always hear local / radio / emote / notifications when in the game
+            // can always hear local / radio / emote / notifications / narration when in the game
             FilterableChannels |= ChatChannel.Local;
             FilterableChannels |= ChatChannel.Whisper;
             FilterableChannels |= ChatChannel.Radio;
             FilterableChannels |= ChatChannel.Emotes;
             FilterableChannels |= ChatChannel.Notifications;
+            FilterableChannels |= ChatChannel.Narration;
 
             // Can only send local / radio / emote when attached to a non-ghost entity.
             // TODO: this logic is iffy (checking if controlling something that's NOT a ghost), is there a better way to check this?
@@ -557,6 +560,12 @@ public sealed class ChatUIController : UIController
             FilterableChannels |= ChatChannel.AdminAlert;
             FilterableChannels |= ChatChannel.AdminChat;
             CanSendChannels |= ChatSelectChannel.Admin;
+        }
+
+        // only admins with Fun flag can send narration
+        if (_admin.HasFlag(AdminFlags.Fun))
+        {
+            CanSendChannels |= ChatSelectChannel.Narration;
         }
 
         SelectableChannels = CanSendChannels;

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Local,
         ChatChannel.Whisper,
         ChatChannel.Emotes,
+        ChatChannel.Narration,
         ChatChannel.Radio,
         ChatChannel.Notifications,
         ChatChannel.LOOC,

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
@@ -64,6 +64,7 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
             ChatSelectChannel.OOC => Color.LightSkyBlue,
             ChatSelectChannel.Dead => Color.MediumPurple,
             ChatSelectChannel.Admin => Color.HotPink,
+            ChatSelectChannel.Narration => Color.DarkGray,
             _ => Color.DarkGray
         };
     }

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
@@ -16,7 +16,8 @@ public sealed class ChannelSelectorPopup : Popup
         ChatSelectChannel.LOOC,
         ChatSelectChannel.OOC,
         ChatSelectChannel.Dead,
-        ChatSelectChannel.Admin
+        ChatSelectChannel.Admin,
+        ChatSelectChannel.Narration
         // NOTE: Console is not in there and it can never be permanently selected.
         // You can, however, still submit commands as console by prefixing with /.
     };

--- a/Content.Server/Chat/Commands/NarrateCommand.cs
+++ b/Content.Server/Chat/Commands/NarrateCommand.cs
@@ -1,0 +1,44 @@
+using Content.Server.Administration;
+using Content.Server.Chat.Systems;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+
+namespace Content.Server.Chat.Commands
+{
+    [AdminCommand(AdminFlags.Fun)]
+    internal sealed class NarrateCommand : IConsoleCommand
+    {
+        public string Command => "narrate";
+        public string Description => "Send a narration message visible to nearby players. Admin/GM tool for scene descriptions.";
+        public string Help => "narrate <text>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (shell.Player is not { } player)
+            {
+                shell.WriteError("This command cannot be run from the server.");
+                return;
+            }
+
+            if (player.Status != SessionStatus.InGame)
+                return;
+
+            if (player.AttachedEntity is not {} playerEntity)
+            {
+                shell.WriteError("You don't have an entity!");
+                return;
+            }
+
+            if (args.Length < 1)
+                return;
+
+            var message = string.Join(" ", args).Trim();
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
+                .SendNarration(playerEntity, message, shell, player);
+        }
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -604,6 +604,31 @@ public sealed partial class ChatSystem : SharedChatSystem
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user}: {action}");
     }
 
+    /// <summary>
+    ///     Sends a narration message to players within voice range.
+    ///     Unlike emotes, this does NOT include the entity name - it's a pure scene description.
+    /// </summary>
+    public void SendNarration(EntityUid source, string message, IConsoleShell? shell = null, ICommonSession? player = null)
+    {
+        if (player != null && _chatManager.HandleRateLimit(player) != RateLimitStatus.Allowed)
+            return;
+
+        message = FormattedMessage.EscapeText(message.Trim());
+
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        var wrappedMessage = Loc.GetString("chat-manager-narration-wrap-message",
+            ("message", message));
+
+        SendInVoiceRange(ChatChannel.Narration, message, wrappedMessage, source, ChatTransmitRange.Normal);
+
+        if (player != null)
+            _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Narration from {player:Player}: {message}");
+        else
+            _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Narration from {ToPrettyString(source):user}: {message}");
+    }
+
     // ReSharper disable once InconsistentNaming
     private void SendLOOC(EntityUid source, ICommonSession player, string message, bool hideChat)
     {

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -86,9 +86,14 @@ namespace Content.Shared.Chat
         Unspecified = 1 << 14,
 
         /// <summary>
+        ///     Narration - Admin/GM scene descriptions visible to nearby players.
+        /// </summary>
+        Narration = 1 << 15,
+
+        /// <summary>
         ///     Channels considered to be IC.
         /// </summary>
-        IC = Local | Whisper | Radio | Dead | Emotes | Damage | Visual | Notifications,
+        IC = Local | Whisper | Radio | Dead | Emotes | Damage | Visual | Notifications | Narration,
 
         AdminRelated = Admin | AdminAlert | AdminChat,
     }

--- a/Content.Shared/Chat/ChatSelectChannel.cs
+++ b/Content.Shared/Chat/ChatSelectChannel.cs
@@ -51,6 +51,11 @@
         /// </summary>
         Admin = ChatChannel.AdminChat,
 
-        Console = ChatChannel.Unspecified
+        Console = ChatChannel.Unspecified,
+
+        /// <summary>
+        ///     Narration - Admin/GM scene descriptions
+        /// </summary>
+        Narration = ChatChannel.Narration
     }
 }

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -23,6 +23,7 @@ public abstract class SharedChatSystem : EntitySystem
     public const char EmotesAltPrefix = '*';
     public const char AdminPrefix = ']';
     public const char WhisperPrefix = ',';
+    public const char NarrationPrefix = '!';
     public const char DefaultChannelKey = 'h';
 
     [ValidatePrototypeId<RadioChannelPrototype>]

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -34,6 +34,8 @@ chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
      [true] {CAPITALIZE($entityName)} {$message}[/italic]
     }
 
+chat-manager-narration-wrap-message = [italic]{$message}[/italic]
+
 chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$message}
 chat-manager-send-ooc-wrap-message = OOC: [bold]{$playerName}:[/bold] {$message}
 chat-manager-send-ooc-patron-wrap-message = OOC: [bold][color={$patronColor}]{$playerName}[/color]:[/bold] {$message}

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -15,6 +15,7 @@ hud-chatbox-select-channel-OOC = OOC
 hud-chatbox-select-channel-Damage = Damage
 hud-chatbox-select-channel-Visual = Actions
 hud-chatbox-select-channel-Radio = Radio
+hud-chatbox-select-channel-Narration = Narration
 
 hud-chatbox-channel-Admin = Admin Misc
 hud-chatbox-channel-AdminAlert = Admin Alert
@@ -31,3 +32,4 @@ hud-chatbox-channel-Server = Server
 hud-chatbox-channel-Visual = Actions
 hud-chatbox-channel-Damage = Damage
 hud-chatbox-channel-Unspecified = Unspecified
+hud-chatbox-channel-Narration = Narration


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added a new **Narration** chat channel for admins and GMs to send immersive scene descriptions to nearby players.

### Features:
- New `narrate` command for admins (`AdminFlags.Fun` permission required)
- Messages appear in italics without showing sender name - perfect for atmospheric descriptions
- Range-based visibility - only nearby players see the narration
- New chat channel filter option so players can toggle narration visibility
- Selectable from the channel selector in chat UI

### Use Cases:
- GMs describing environmental events ("*The ground shakes as thunder rolls across the zone...*")
- Setting atmosphere during events
- Describing NPC actions or environmental changes
- Immersive storytelling without breaking character

## Changelog

author: @teecoding 

- add: Narration chat channel for admin/GM scene descriptions

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
