### PR TITLE
perf(weather): cache emission checks, batch network updates, and reuse client flood-fill collections

### DIFF
--- a/Content.Client/Weather/WeatherSystem.cs
+++ b/Content.Client/Weather/WeatherSystem.cs
@@ -19,6 +19,13 @@ public sealed class WeatherSystem : SharedWeatherSystem
     [Dependency] private readonly MapSystem _mapSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
+    // Reused collections for flood-fill to avoid per-frame allocations
+    private readonly Queue<TileRef> _floodFrontier = new();
+    private readonly HashSet<Vector2i> _floodVisited = new();
+    private Vector2i? _lastPlayerTile;
+    private EntityUid? _lastGridUid;
+    private EntityCoordinates? _cachedNearestNode;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -60,50 +67,57 @@ public sealed class WeatherSystem : SharedWeatherSystem
             var gridId = entXform.GridUid.Value;
             // FloodFill to the nearest tile and use that for audio.
             var seed = _mapSystem.GetTileRef(gridId, grid, entXform.Coordinates);
-            var frontier = new Queue<TileRef>();
-            frontier.Enqueue(seed);
-            // If we don't have a nearest node don't play any sound.
-            EntityCoordinates? nearestNode = null;
-            var visited = new HashSet<Vector2i>();
+            var currentTile = seed.GridIndices;
 
-            while (frontier.TryDequeue(out var node))
+            // Only recalculate when player moves to new tile or changes grid
+            if (_lastPlayerTile != currentTile || _lastGridUid != gridId)
             {
-                if (!visited.Add(node.GridIndices))
-                    continue;
+                _lastPlayerTile = currentTile;
+                _lastGridUid = gridId;
 
-                if (!CanWeatherAffect(entXform.GridUid.Value, grid, node))
+                _floodFrontier.Clear();
+                _floodVisited.Clear();
+                _floodFrontier.Enqueue(seed);
+                _cachedNearestNode = null;
+
+                while (_floodFrontier.TryDequeue(out var node))
                 {
-                    // Add neighbors
-                    // TODO: Ideally we pick some deterministically random direction and use that
-                    // We can't just do that naively here because it will flicker between nearby tiles.
-                    for (var x = -1; x <= 1; x++)
-                    {
-                        for (var y = -1; y <= 1; y++)
-                        {
-                            if (Math.Abs(x) == 1 && Math.Abs(y) == 1 ||
-                                x == 0 && y == 0 ||
-                                (new Vector2(x, y) + node.GridIndices - seed.GridIndices).Length() > 3)
-                            {
-                                continue;
-                            }
+                    if (!_floodVisited.Add(node.GridIndices))
+                        continue;
 
-                            frontier.Enqueue(_mapSystem.GetTileRef(gridId, grid, new Vector2i(x, y) + node.GridIndices));
+                    if (!CanWeatherAffect(gridId, grid, node))
+                    {
+                        // Add neighbors
+                        // TODO: Ideally we pick some deterministically random direction and use that
+                        // We can't just do that naively here because it will flicker between nearby tiles.
+                        for (var x = -1; x <= 1; x++)
+                        {
+                            for (var y = -1; y <= 1; y++)
+                            {
+                                if (Math.Abs(x) == 1 && Math.Abs(y) == 1 ||
+                                    x == 0 && y == 0 ||
+                                    (new Vector2(x, y) + node.GridIndices - seed.GridIndices).Length() > 3)
+                                {
+                                    continue;
+                                }
+
+                                _floodFrontier.Enqueue(_mapSystem.GetTileRef(gridId, grid, new Vector2i(x, y) + node.GridIndices));
+                            }
                         }
+
+                        continue;
                     }
 
-                    continue;
+                    _cachedNearestNode = new EntityCoordinates(gridId, node.GridIndices + grid.TileSizeHalfVector);
+                    break;
                 }
-
-                nearestNode = new EntityCoordinates(entXform.GridUid.Value,
-                    node.GridIndices + grid.TileSizeHalfVector);
-                break;
             }
 
             // Get occlusion to the targeted node if it exists, otherwise set a default occlusion.
-            if (nearestNode != null)
+            if (_cachedNearestNode != null)
             {
                 var entPos = _transform.GetMapCoordinates(entXform);
-                var nodePosition = _transform.ToMapCoordinates(nearestNode.Value).Position;
+                var nodePosition = _transform.ToMapCoordinates(_cachedNearestNode.Value).Position;
                 var delta = nodePosition - entPos.Position;
                 var distance = delta.Length();
                 occlusion = _audio.GetOcclusion(entPos, delta, distance);

--- a/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleComponent.cs
+++ b/Content.Server/_Stalker_EN/Weather/WeatherSchedulerRuleComponent.cs
@@ -41,4 +41,6 @@ public sealed partial class WeatherSchedulerRuleComponent : Component
     public TimeSpan NextWeatherChangeTime;
     public ProtoId<WeatherPrototype>? CurrentWeather;
     public bool WaitingForEmission;
+    public bool CachedEmissionActive;
+    public TimeSpan NextEmissionCheckTime;
 }


### PR DESCRIPTION
**Dependencies:** This PR depends on [#335](https://github.com/coolmankid12345/stalker-14-EN/pull/335) and must be merged after it.

<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Performance optimizations for the weather scheduler system to reduce CPU and network overhead:

**1. Emission Check Caching (Server)**
- Previously: `IsEmissionActive()` performed an entity query every frame, even when weather change was 10+ minutes away
- Now: Only checks emission when close to weather change time (within 5 seconds) or periodically (every 2 seconds) during active emission

**2. Network Update Batching (Shared)**
- Previously: `SetWeather()` called `Dirty()` multiple times per weather change, each triggering network sync
- Now: Tracks modifications with a flag and calls `Dirty()` once after all changes are complete

**3. Client Collection Reuse**
- Previously: Allocated new `Queue<TileRef>` and `HashSet<Vector2i>` every frame during active weather
- Now: Reuses class-level collections and caches flood-fill results, only recalculating when player moves to a new tile

## Changelog

author: @teecoding 

- tweak: Improved weather scheduler performance by caching emission checks, batching network updates, and reusing client collections

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
