### PR TITLE
feat(stash): comment out quick store button from repository menu

### DIFF
--- a/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryBoundUserInterface.cs
+++ b/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryBoundUserInterface.cs
@@ -47,10 +47,10 @@ public sealed class StalkerRepositoryBoundUserInterface : BoundUserInterface
         _menu.OpenLoadoutsPressed += OpenLoadoutMenu;
 
         // Quick Store button deposits all equipped items to stash
-        _menu.QuickStorePressed += () =>
-        {
-            SendMessage(new LoadoutQuickStoreMessage());
-        };
+        // _menu.QuickStorePressed += () =>
+        // {
+        //     SendMessage(new LoadoutQuickStoreMessage());
+        // };
     }
 
     private void OpenLoadoutMenu()
@@ -117,10 +117,10 @@ public sealed class StalkerRepositoryBoundUserInterface : BoundUserInterface
                 SendMessage(new RepositoryEjectMessage(item, count));
             };
             _menu.OpenLoadoutsPressed += OpenLoadoutMenu;
-            _menu.QuickStorePressed += () =>
-            {
-                SendMessage(new LoadoutQuickStoreMessage());
-            };
+            // _menu.QuickStorePressed += () =>
+            // {
+            //     SendMessage(new LoadoutQuickStoreMessage());
+            // };
         }
 
         if (!_menu.IsOpen)

--- a/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml
+++ b/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml
@@ -38,7 +38,7 @@
         <!-- Loadouts and Quick Store Buttons -->
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="4 4 4 4">
             <Control HorizontalExpand="True"/>
-            <Button Name="QuickStoreButton" Text="{Loc 'loadout-quick-store'}" MinWidth="120" Margin="0 0 8 0"/>
+            <!-- <Button Name="QuickStoreButton" Text="{Loc 'loadout-quick-store'}" MinWidth="120" Margin="0 0 8 0"/> -->
             <Button Name="OpenLoadoutsButton" Text="{Loc 'loadout-open-button'}" MinWidth="120"/>
         </BoxContainer>
     </BoxContainer>

--- a/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml.cs
+++ b/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class StalkerRepositoryMenu : DefaultWindow
     public event Action<RepositoryItemInfo, int>? RepositoryButtonPutPressed;
     public event Action<RepositoryItemInfo, int>? RepositoryButtonGetPressed;
     public event Action? OpenLoadoutsPressed;
-    public event Action? QuickStorePressed;
+    // public event Action? QuickStorePressed;
 
     private (string, int) _currentCategory;
     private List<RepositoryItemInfo>? _curItems;
@@ -58,7 +58,7 @@ public sealed partial class StalkerRepositoryMenu : DefaultWindow
         OpenLoadoutsButton.OnPressed += _ => OpenLoadoutsPressed?.Invoke();
 
         // Quick Store button deposits all equipped items to stash
-        QuickStoreButton.OnPressed += _ => QuickStorePressed?.Invoke();
+        // QuickStoreButton.OnPressed += _ => QuickStorePressed?.Invoke();
     }
 
     private void OnTextChanged(LineEdit.LineEditEventArgs args)


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Disabled the Quick Store button in the personal stash (StalkerRepository) UI by commenting out the relevant code due to being buggy

The Loadouts button remains functional.

## Changelog
author: @teecoding

- remove: Quick Store button from personal stash UI

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
