### PR TITLE
feat(pda): add silent mode toggle with dynamic button text and popup feedback

### DIFF
--- a/Content.Client/PDA/PdaBoundUserInterface.cs
+++ b/Content.Client/PDA/PdaBoundUserInterface.cs
@@ -1,4 +1,5 @@
 using Content.Client.CartridgeLoader;
+using Content.Shared._Stalker_EN.PDA.Ringer;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.PDA;
@@ -61,6 +62,11 @@ namespace Content.Client.PDA
             _menu.AccessRingtoneButton.OnPressed += _ =>
             {
                 SendMessage(new PdaShowRingtoneMessage());
+            };
+
+            _menu.SilentModeButton.OnPressed += _ =>
+            {
+                SendMessage(new STPdaToggleSilentModeMessage());
             };
 
             _menu.ShowUplinkButton.OnPressed += _ =>

--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -65,6 +65,10 @@
                                        Access="Public"
                                        Text="{Loc 'comp-pda-ui-ringtone-button'}"
                                        Description="{Loc 'comp-pda-ui-ringtone-button-description'}"/>
+                <pda:PdaSettingsButton Name="SilentModeButton"
+                                       Access="Public"
+                                       Text="{Loc 'comp-pda-ui-silent-mode-button-off'}"
+                                       Description="{Loc 'comp-pda-ui-silent-mode-button-description'}"/>
                 <pda:PdaSettingsButton Name="ActivateMusicButton"
                                        Access="Public"
                                        Visible="False"

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -191,6 +191,12 @@ namespace Content.Client.PDA
             ActivateMusicButton.Visible = state.CanPlayMusic;
             ShowUplinkButton.Visible = state.HasUplink;
             LockUplinkButton.Visible = state.HasUplink;
+
+            // stalker-changes-start - Update silent mode button text based on state
+            SilentModeButton.Text = state.SilentModeEnabled
+                ? Loc.GetString("comp-pda-ui-silent-mode-button-on")
+                : Loc.GetString("comp-pda-ui-silent-mode-button-off");
+            // stalker-changes-end
         }
 
         public void UpdateAvailablePrograms(List<(EntityUid, CartridgeComponent)> programs)

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Light.Components;
 using Content.Shared.Light.EntitySystems;
 using Content.Shared.PDA;
 using Content.Shared.Store.Components;
+using Content.Shared._Stalker_EN.PDA.Ringer; // stalker-changes
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
@@ -182,6 +183,11 @@ namespace Content.Server.PDA
 
             var programs = _cartridgeLoader.GetAvailablePrograms(uid, loader);
             var id = CompOrNull<IdCardComponent>(pda.ContainedId);
+
+            // stalker-changes-start
+            var silentModeEnabled = TryComp<STSilentModeComponent>(uid, out var silentMode) && silentMode.Enabled;
+            // stalker-changes-end
+
             var state = new PdaUpdateState(
                 programs,
                 GetNetEntity(loader.ActiveProgram),
@@ -199,7 +205,8 @@ namespace Content.Server.PDA
                 pda.StationName,
                 showUplink,
                 hasInstrument,
-                address);
+                address,
+                silentModeEnabled); // stalker-changes
 
             _ui.SetUiState(uid, PdaUiKey.Key, state);
         }

--- a/Content.Server/_Stalker_EN/PDA/Ringer/STSilentModeSystem.cs
+++ b/Content.Server/_Stalker_EN/PDA/Ringer/STSilentModeSystem.cs
@@ -1,0 +1,50 @@
+using Content.Server.PDA;
+using Content.Server.PDA.Ringer;
+using Content.Shared._Stalker_EN.PDA.Ringer;
+using Content.Shared.PDA;
+using Content.Shared.Popups;
+
+namespace Content.Server._Stalker_EN.PDA.Ringer;
+
+/// <summary>
+/// Handles the silent mode feature for PDA ringers.
+/// Automatically adds STSilentModeComponent to all entities with RingerComponent
+/// and handles toggle messages from the UI.
+/// </summary>
+public sealed class STSilentModeSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly PdaSystem _pda = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RingerComponent, ComponentInit>(OnRingerInit);
+        SubscribeLocalEvent<PdaComponent, STPdaToggleSilentModeMessage>(OnToggleSilentMode);
+    }
+
+    private void OnRingerInit(EntityUid uid, RingerComponent component, ComponentInit args)
+    {
+        EnsureComp<STSilentModeComponent>(uid);
+    }
+
+    private void OnToggleSilentMode(EntityUid uid, PdaComponent component, STPdaToggleSilentModeMessage args)
+    {
+        if (!PdaUiKey.Key.Equals(args.UiKey))
+            return;
+
+        if (!TryComp<STSilentModeComponent>(uid, out var silentMode))
+            return;
+
+        silentMode.Enabled = !silentMode.Enabled;
+        Dirty(uid, silentMode);
+
+        var message = silentMode.Enabled
+            ? Loc.GetString("comp-pda-ui-silent-mode-enabled")
+            : Loc.GetString("comp-pda-ui-silent-mode-disabled");
+        _popup.PopupEntity(message, uid, args.Actor, PopupType.Small);
+
+        _pda.UpdatePdaUi(uid);
+    }
+}

--- a/Content.Shared/PDA/PdaUpdateState.cs
+++ b/Content.Shared/PDA/PdaUpdateState.cs
@@ -16,6 +16,7 @@ namespace Content.Shared.PDA
         public bool HasUplink;
         public bool CanPlayMusic;
         public string? Address;
+        public bool SilentModeEnabled; // stalker-changes
 
         public PdaUpdateState(
             List<NetEntity> programs,
@@ -27,7 +28,8 @@ namespace Content.Shared.PDA
             string? stationName,
             bool hasUplink = false,
             bool canPlayMusic = false,
-            string? address = null)
+            string? address = null,
+            bool silentModeEnabled = false) // stalker-changes
             : base(programs, activeUI)
         {
             FlashlightEnabled = flashlightEnabled;
@@ -38,6 +40,7 @@ namespace Content.Shared.PDA
             CanPlayMusic = canPlayMusic;
             StationName = stationName;
             Address = address;
+            SilentModeEnabled = silentModeEnabled; // stalker-changes
         }
     }
 

--- a/Content.Shared/_Stalker_EN/PDA/Ringer/STPdaSilentModeMessages.cs
+++ b/Content.Shared/_Stalker_EN/PDA/Ringer/STPdaSilentModeMessages.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Stalker_EN.PDA.Ringer;
+
+/// <summary>
+/// Message sent from the PDA UI to toggle silent mode on/off.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class STPdaToggleSilentModeMessage : BoundUserInterfaceMessage
+{
+    public STPdaToggleSilentModeMessage() { }
+}

--- a/Content.Shared/_Stalker_EN/PDA/Ringer/STSilentModeComponent.cs
+++ b/Content.Shared/_Stalker_EN/PDA/Ringer/STSilentModeComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.PDA.Ringer;
+
+/// <summary>
+/// Component that enables silent mode on a PDA ringer.
+/// When enabled, the PDA will be completely silent - no ringtone sounds and no "PDA vibrates" popup.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STSilentModeComponent : Component
+{
+    /// <summary>
+    /// Whether silent mode is currently enabled.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled;
+}

--- a/Resources/Locale/en-US/_Stalker_EN/pda/silent-mode.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/pda/silent-mode.ftl
@@ -1,0 +1,5 @@
+comp-pda-ui-silent-mode-button-on = Silent Mode: On
+comp-pda-ui-silent-mode-button-off = Silent Mode: Off
+comp-pda-ui-silent-mode-button-description = Toggle ringtone sounds on/off
+comp-pda-ui-silent-mode-enabled = Silent mode enabled
+comp-pda-ui-silent-mode-disabled = Silent mode disabled


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added silent mode feature to PDA with enhanced user feedback:

- **Silent Mode Toggle**: New button in PDA Settings to mute ringtone sounds
- **Dynamic Button Text**: Button displays current state ("Silent Mode: On" / "Silent Mode: Off")
- **Popup Feedback**: Shows confirmation popup when toggling ("Silent mode enabled" / "Silent mode disabled")
- **State Sync**: Button text persists correctly when reopening PDA

## Changelog

author: @teecoding 

- add: PDA silent mode toggle that mutes ringtone sounds with visual feedback

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
