### PR TITLE
fix(loadout): preserve nested items when container already equipped

### DIFF
--- a/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
+++ b/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
@@ -822,7 +822,8 @@ public sealed class LoadoutSystem : EntitySystem
                 {
                     if (slotItem.NestedItems.Count > 0)
                     {
-                        ClearAutoFilledContents(currentEquipped.item);
+                        // Don't clear - item is already equipped with matching identifier.
+                        // RestoreNestedItems will find existing items via FindExistingCorrectItem.
                         RestoreNestedItems(currentEquipped.item, slotItem.NestedItems, repository, stashLookup, 0, player, consumedExistingItems);
                     }
                 }
@@ -840,7 +841,8 @@ public sealed class LoadoutSystem : EntitySystem
             {
                 if (slotItem.NestedItems.Count > 0)
                 {
-                    ClearAutoFilledContents(movedItem.Value);
+                    // Don't clear - item was moved, but contents should be preserved.
+                    // RestoreNestedItems will find existing items via FindExistingCorrectItem.
                     RestoreNestedItems(movedItem.Value, slotItem.NestedItems, repository, stashLookup, 0, player, consumedExistingItems);
                 }
                 continue;


### PR DESCRIPTION
## What I changed

Fixed a bug where loading a loadout while already having the container equipped would delete nested items and consume replacements from stash.

**Root cause:** `ApplyLoadout` called `ClearAutoFilledContents()` on already-equipped containers before `RestoreNestedItems()`. This deleted all nested items, so `FindExistingCorrectItem()` found nothing and pulled replacements from stash.

**Pattern:** Player has bag with 4 bottles + 4 in stash. Load loadout → `ClearAutoFilledContents()` deletes bag's 4 bottles → `RestoreNestedItems()` pulls 4 from stash → net loss of 4 bottles.

**Fix:** Removed `ClearAutoFilledContents()` calls for Cases 1 and 2 (already-equipped items). `FindExistingCorrectItem()` now correctly finds existing items and skips stash consumption. Case 3 (stash-spawned items) still clears StorageFill defaults as intended.

## Changelog

author: @teecoding 

- fix: Loading a loadout no longer deletes items inside your bags and containers

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
