### PR TITLE
feat(respawn): add confirmation dialog before respawning dead players

### DIFF
--- a/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
+++ b/Content.Client/UserInterface/Systems/DamageOverlays/Overlays/DamageOverlay.cs
@@ -77,11 +77,11 @@ public sealed class DamageOverlay : Overlay
         var time = (float) _timing.RealTime.TotalSeconds;
         var lastFrameTime = (float) _timing.FrameTime.TotalSeconds;
 
-        //stalker-changes-start
+        // stalker-changes-start
+        // Don't show any overlay when dead - player should see the world
+        // Death screen is shown via STRespawnConfirmSystem when player confirms respawn
         if (State == MobState.Dead)
         {
-            handle.UseShader(null);
-            handle.DrawRect(viewport, Color.Black);
             return;
         }
         // stalker-changes-end

--- a/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmEui.cs
+++ b/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmEui.cs
@@ -1,0 +1,40 @@
+using Content.Client.Eui;
+using Content.Shared._Stalker_EN.RespawnConfirm;
+using JetBrains.Annotations;
+using Robust.Client.Graphics;
+
+namespace Content.Client._Stalker_EN.RespawnConfirm;
+
+[UsedImplicitly]
+public sealed class STRespawnConfirmEui : BaseEui
+{
+    private readonly STRespawnConfirmWindow _window;
+
+    public STRespawnConfirmEui()
+    {
+        _window = new STRespawnConfirmWindow();
+
+        _window.DenyButton.OnPressed += _ =>
+        {
+            SendMessage(new STRespawnConfirmMessage(STRespawnConfirmButton.Deny));
+            _window.Close();
+        };
+
+        _window.AcceptButton.OnPressed += _ =>
+        {
+            SendMessage(new STRespawnConfirmMessage(STRespawnConfirmButton.Accept));
+            _window.Close();
+        };
+    }
+
+    public override void Opened()
+    {
+        IoCManager.Resolve<IClyde>().RequestWindowAttention();
+        _window.OpenCentered();
+    }
+
+    public override void Closed()
+    {
+        _window.Close();
+    }
+}

--- a/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmWindow.cs
+++ b/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmWindow.cs
@@ -1,0 +1,39 @@
+using System.Numerics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Localization;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+
+namespace Content.Client._Stalker_EN.RespawnConfirm;
+
+public sealed class STRespawnConfirmWindow : DefaultWindow
+{
+    public readonly Button DenyButton;
+    public readonly Button AcceptButton;
+
+    public STRespawnConfirmWindow()
+    {
+        Title = Loc.GetString("st-respawn-confirm-title");
+
+        Contents.AddChild(new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical,
+            Children =
+            {
+                new Label { Text = Loc.GetString("st-respawn-confirm-text") },
+                new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Horizontal,
+                    Align = AlignMode.Center,
+                    Children =
+                    {
+                        (AcceptButton = new Button { Text = Loc.GetString("st-respawn-confirm-yes") }),
+                        new Control { MinSize = new Vector2(20, 0) },
+                        (DenyButton = new Button { Text = Loc.GetString("st-respawn-confirm-no") })
+                    }
+                }
+            }
+        });
+    }
+}

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._Stalker.Mind;
+using Content.Server._Stalker_EN.RespawnConfirm;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
@@ -64,6 +65,7 @@ namespace Content.Server.Ghost
         [Dependency] private readonly GameTicker _gameTicker = default!;
         [Dependency] private readonly DamageableSystem _damageable = default!;
         [Dependency] private readonly IServerConsoleHost _consoleHost = default!;
+        [Dependency] private readonly STRespawnConfirmSystem _respawnConfirm = default!;
 
         private EntityQuery<GhostComponent> _ghostQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -514,9 +516,11 @@ namespace Content.Server.Ghost
             if (!Resolve(mindId, ref mind))
                 return false;
             // stalker-changes-start
-            if (mind.Session != null)
+            // Show respawn confirm for players who move while dead (not via command)
+            // Ghost command is admin-only, so skip the confirm dialog for admins
+            if (!viaCommand && mind.Session != null)
             {
-                _gameTicker.Respawn(mind.Session);
+                _respawnConfirm.ShowRespawnConfirm(mind.Session);
                 return false;
             }
 

--- a/Content.Server/_RD/DeathScreen/RDDeathScreenSystem.cs
+++ b/Content.Server/_RD/DeathScreen/RDDeathScreenSystem.cs
@@ -30,6 +30,9 @@ public sealed class RDDeathScreenSystem : RDEntitySystem
         if (player is null)
             return;
 
-        RaiseNetworkEvent(new RDDeathScreenShowEvent("lost to the Zone", audioPath: "/Audio/_RD/DeathScreen/controller.ogg"), player.Channel);
+        // stalker-changes-start
+        // Don't show death screen automatically for players - they go through STRespawnConfirmSystem
+        // which shows the death screen after the player confirms they want to respawn
+        // stalker-changes-end
     }
 }

--- a/Content.Server/_Stalker_EN/RespawnConfirm/STRespawnConfirmSystem.cs
+++ b/Content.Server/_Stalker_EN/RespawnConfirm/STRespawnConfirmSystem.cs
@@ -1,0 +1,170 @@
+using Content.Server.EUI;
+using Content.Server.GameTicking;
+using Content.Shared._Stalker_EN.RespawnConfirm;
+using Content.Shared._RD.DeathScreen;
+using Content.Shared.Eui;
+using Robust.Shared.Localization;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Stalker_EN.RespawnConfirm;
+
+/// <summary>
+/// Server-side EUI handler for the respawn confirmation dialog.
+/// Handles player responses (accept/deny) and communicates with <see cref="STRespawnConfirmSystem"/>.
+/// </summary>
+public sealed class STRespawnConfirmEui : BaseEui
+{
+    private readonly STRespawnConfirmSystem _system;
+    private readonly ICommonSession _session;
+    private bool _handled;
+
+    public STRespawnConfirmEui(STRespawnConfirmSystem system, ICommonSession session)
+    {
+        _system = system;
+        _session = session;
+    }
+
+    public override void HandleMessage(EuiMessageBase msg)
+    {
+        base.HandleMessage(msg);
+
+        if (_handled)
+            return;
+
+        _handled = true;
+
+        if (msg is not STRespawnConfirmMessage choice ||
+            choice.Button == STRespawnConfirmButton.Deny)
+        {
+            _system.HandleRespawnDenied(_session);
+            Close();
+            return;
+        }
+
+        // Player accepted - trigger death screen then respawn
+        _system.HandleRespawnAccepted(_session);
+        Close();
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+
+        // Only handle if not already handled (e.g., player disconnected before choosing)
+        if (_handled)
+            return;
+
+        _handled = true;
+        _system.HandleRespawnDenied(_session);
+    }
+}
+
+/// <summary>
+/// Manages the respawn confirmation flow for dead players.
+/// When a player moves while dead (attempting to ghost), shows a confirmation dialog.
+/// If accepted, displays a death screen and schedules respawn after the animation completes.
+/// </summary>
+public sealed class STRespawnConfirmSystem : EntitySystem
+{
+    [Dependency] private readonly EuiManager _euiManager = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    /// <summary>
+    /// Track sessions with pending respawns (after death screen shown)
+    /// </summary>
+    private readonly Dictionary<ICommonSession, TimeSpan> _pendingRespawns = new();
+
+    /// <summary>
+    /// Track sessions with open confirmation EUIs (prevent duplicates)
+    /// </summary>
+    private readonly HashSet<ICommonSession> _openConfirms = new();
+
+    /// <summary>
+    /// Duration to wait before respawning after death screen is shown.
+    /// Matches the death screen animation: 4 seconds fade + 3 seconds delay.
+    /// </summary>
+    private static readonly TimeSpan DeathScreenDuration = TimeSpan.FromSeconds(7);
+
+    /// <summary>
+    /// Audio path for the death screen sound effect.
+    /// </summary>
+    private const string DeathScreenAudioPath = "/Audio/_RD/DeathScreen/controller.ogg";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<PlayerDetachedEvent>(OnPlayerDetached);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var toRemove = new List<ICommonSession>();
+        foreach (var (session, respawnTime) in _pendingRespawns)
+        {
+            if (_timing.CurTime >= respawnTime)
+            {
+                _gameTicker.Respawn(session);
+                toRemove.Add(session);
+            }
+        }
+
+        foreach (var session in toRemove)
+        {
+            _pendingRespawns.Remove(session);
+        }
+    }
+
+    private void OnPlayerDetached(PlayerDetachedEvent args)
+    {
+        // Clean up if player disconnects
+        _openConfirms.Remove(args.Player);
+        _pendingRespawns.Remove(args.Player);
+    }
+
+    /// <summary>
+    /// Called from GhostSystem when player attempts to ghost (moves while dead)
+    /// </summary>
+    public void ShowRespawnConfirm(ICommonSession session)
+    {
+        // Don't show duplicate dialogs
+        if (_openConfirms.Contains(session))
+            return;
+
+        // Don't show if already pending respawn
+        if (_pendingRespawns.ContainsKey(session))
+            return;
+
+        var eui = new STRespawnConfirmEui(this, session);
+        _euiManager.OpenEui(eui, session);
+        _openConfirms.Add(session);
+    }
+
+    /// <summary>
+    /// Called when player denies/cancels respawn or closes the dialog
+    /// </summary>
+    public void HandleRespawnDenied(ICommonSession session)
+    {
+        _openConfirms.Remove(session);
+    }
+
+    /// <summary>
+    /// Called when player confirms respawn
+    /// </summary>
+    public void HandleRespawnAccepted(ICommonSession session)
+    {
+        _openConfirms.Remove(session);
+
+        // Show death screen
+        RaiseNetworkEvent(new RDDeathScreenShowEvent(
+            Loc.GetString("st-respawn-death-screen-message"),
+            audioPath: DeathScreenAudioPath),
+            session.Channel);
+
+        // Schedule respawn after death screen completes
+        _pendingRespawns[session] = _timing.CurTime + DeathScreenDuration;
+    }
+}

--- a/Content.Shared/_Stalker_EN/RespawnConfirm/STRespawnConfirmEuiMessage.cs
+++ b/Content.Shared/_Stalker_EN/RespawnConfirm/STRespawnConfirmEuiMessage.cs
@@ -1,0 +1,22 @@
+using Content.Shared.Eui;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Stalker_EN.RespawnConfirm;
+
+[Serializable, NetSerializable]
+public enum STRespawnConfirmButton
+{
+    Deny,
+    Accept,
+}
+
+[Serializable, NetSerializable]
+public sealed class STRespawnConfirmMessage : EuiMessageBase
+{
+    public readonly STRespawnConfirmButton Button;
+
+    public STRespawnConfirmMessage(STRespawnConfirmButton button)
+    {
+        Button = button;
+    }
+}

--- a/Resources/Locale/en-US/_Stalker_EN/respawn-confirm.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/respawn-confirm.ftl
@@ -1,0 +1,5 @@
+st-respawn-confirm-title = Respawn
+st-respawn-confirm-text = Do you want to respawn? You can wait to be revived by other players.
+st-respawn-confirm-yes = Respawn
+st-respawn-confirm-no = Cancel
+st-respawn-death-screen-message = lost to the Zone


### PR DESCRIPTION
## What I changed

Added a respawn confirmation dialog system that gives dead players time to be revived before respawning.

**New Death Flow:**
1. Player dies → no overlay
2. Player presses movement while dead → confirmation popup appears: "Do you want to respawn?"
3. Click "Cancel" → popup closes, player stays dead
4. Click "Respawn" → death screen with "lost to the Zone" audio plays → respawns after ~7 seconds

**Additional changes:**
- Removed automatic black screen overlay on death (players can now see while dead)
- Disabled automatic death screen trigger on death (only shows after confirming respawn)

## Changelog

author: @teecoding 
- add: You can now choose when to respawn after death, giving teammates time to revive you
- tweak: You can see the world while dead instead of a black screen

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
