### PR TITLE
fix(chat): initialize typing indicator time for items in containers on map init

### DIFF
--- a/Content.Shared/Chat/TypingIndicator/SharedTypingIndicatorSystem.cs
+++ b/Content.Shared/Chat/TypingIndicator/SharedTypingIndicatorSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Clothing;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Inventory;
+using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
@@ -13,6 +15,7 @@ public abstract class SharedTypingIndicatorSystem : EntitySystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     /// <summary>
@@ -30,6 +33,7 @@ public abstract class SharedTypingIndicatorSystem : EntitySystem
         SubscribeLocalEvent<TypingIndicatorClothingComponent, ClothingGotEquippedEvent>(OnGotEquipped);
         SubscribeLocalEvent<TypingIndicatorClothingComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
         SubscribeLocalEvent<TypingIndicatorClothingComponent, InventoryRelayedEvent<BeforeShowTypingIndicatorEvent>>(BeforeShow);
+        SubscribeLocalEvent<TypingIndicatorClothingComponent, MapInitEvent>(OnMapInit);
 
         SubscribeAllEvent<TypingChangedEvent>(OnTypingChanged);
     }
@@ -57,6 +61,21 @@ public abstract class SharedTypingIndicatorSystem : EntitySystem
     private void OnGotUnequipped(Entity<TypingIndicatorClothingComponent> entity, ref ClothingGotUnequippedEvent args)
     {
         entity.Comp.GotEquippedTime = null;
+        Dirty(entity);
+    }
+
+    private void OnMapInit(Entity<TypingIndicatorClothingComponent> entity, ref MapInitEvent args)
+    {
+        // ClothingGotEquippedEvent doesn't fire for items restored from serialization
+        if (entity.Comp.GotEquippedTime != null)
+            return;
+
+        // Items not in containers aren't equipped and shouldn't override typing indicators
+        if (!_containerSystem.TryGetContainingContainer((entity.Owner, null, null), out _))
+            return;
+
+        // TryUpdateTimeAndIndicator rejects null times, causing fallback to default indicator
+        entity.Comp.GotEquippedTime = _timing.CurTime;
         Dirty(entity);
     }
 


### PR DESCRIPTION
## What I changed

Fixed chat bubble typing indicators falling back to "default" state when a dogtag is equipped via loadout or restored from serialization (reconnect/round restart).

**Root cause:** `GotEquippedTime` in `TypingIndicatorClothingComponent` was only set when `ClothingGotEquippedEvent` fires. Items restored from serialization or spawned already inside containers didn't trigger this event, causing `TryUpdateTimeAndIndicator()` to reject the null time and fall back to default.

**Solution:** Added a `MapInitEvent` handler to initialize `GotEquippedTime` for items already in containers at map initialization.

*Might not fix it, but this should get us closer at solving the issue where the typing indicator keeps falling to default state.*

## Changelog

author: @teecoding
- fix: Possible fix for faction dogtags not showing correct chat bubbles when spawning or reconnecting

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
