### PR TITLE
fix(radio): detect queued-for-deletion actions during loadout restore

### DIFF
--- a/Content.Server/_Stalker_EN/Radio/STRadioHeadsetSystem.cs
+++ b/Content.Server/_Stalker_EN/Radio/STRadioHeadsetSystem.cs
@@ -56,29 +56,16 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
     {
         base.Initialize();
 
-        // Action button events
         SubscribeLocalEvent<STRadioHeadsetComponent, STRadioHeadsetToggleMicActionEvent>(OnToggleMicAction);
-
-        // Equipment events for managing ActiveRadioComponent
         SubscribeLocalEvent<STRadioHeadsetComponent, GotEquippedEvent>(OnEquipped);
         SubscribeLocalEvent<STRadioHeadsetComponent, GotUnequippedEvent>(OnUnequipped);
-
-        // Radio receive event - send messages directly to wearer only
         SubscribeLocalEvent<STRadioHeadsetComponent, RadioReceiveEvent>(OnRadioReceive);
-
-        // UI panel messages - use our own message types instead of upstream ones
         SubscribeLocalEvent<STRadioHeadsetComponent, STRadioHeadsetToggleMicMessage>(OnUiToggleMic,
             after: new[] { typeof(RadioDeviceSystem) });
         SubscribeLocalEvent<STRadioHeadsetComponent, STRadioHeadsetSelectFrequencyMessage>(OnUiSelectFrequency);
-
-        // UI open event
         SubscribeLocalEvent<STRadioHeadsetComponent, BeforeActivatableUIOpenEvent>(OnBeforeUiOpen);
     }
 
-    /// <summary>
-    /// Initializes the default frequency on the RadioStalkerComponent when the headset is spawned.
-    /// Calls base to set up actions, then sets the default frequency.
-    /// </summary>
     protected override void OnMapInit(Entity<STRadioHeadsetComponent> ent, ref MapInitEvent args)
     {
         base.OnMapInit(ent, ref args);
@@ -86,7 +73,6 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         if (!TryComp<RadioStalkerComponent>(ent, out var stalkerComp))
             return;
 
-        // Only set default if no frequency is configured
         if (string.IsNullOrEmpty(stalkerComp.CurrentFrequency))
         {
             stalkerComp.CurrentFrequency = STRadioHeadsetComponent.DefaultFrequency;
@@ -94,17 +80,20 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         }
     }
 
-    /// <summary>
-    /// Activates the radio headset when equipped to the ears slot.
-    /// Adds ActiveRadioComponent to enable receiving radio messages on the stalker channel.
-    /// </summary>
     private void OnEquipped(Entity<STRadioHeadsetComponent> ent, ref GotEquippedEvent args)
     {
-        // Only activate radio when equipped to ears slot
         if (!args.SlotFlags.HasFlag(SlotFlags.EARS))
             return;
 
-        // Add ActiveRadioComponent to receive radio messages on StalkerInternal channel
+        // Recreate action if invalid - handles stash retrieval/loadout where DeleteChildren
+        // queues the action for deletion before equip completes.
+        if (!_actions.TryGetActionData(ent.Comp.ToggleMicActionEntity, out _, logError: false))
+        {
+            ent.Comp.ToggleMicActionEntity = null;
+            _actionContainer.EnsureAction(ent, ref ent.Comp.ToggleMicActionEntity, ent.Comp.ToggleMicAction);
+            Dirty(ent);
+        }
+
         var active = EnsureComp<ActiveRadioComponent>(ent);
         active.Channels.Clear();
         active.Channels.Add(StalkerInternalChannel);
@@ -112,12 +101,8 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         UpdateActionStates(ent);
     }
 
-    /// <summary>
-    /// Removes active radio component when the headset is unequipped from the ears slot.
-    /// </summary>
     private void OnUnequipped(Entity<STRadioHeadsetComponent> ent, ref GotUnequippedEvent args)
     {
-        // Only deactivate radio when unequipped from ears slot (matches OnEquipped logic)
         if (!args.SlotFlags.HasFlag(SlotFlags.EARS))
             return;
 
@@ -125,35 +110,28 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
     }
 
     /// <summary>
-    /// Handles receiving radio messages - sends directly to the wearer's client only.
-    /// Does NOT broadcast to nearby players like RadioSpeaker does.
-    /// Constructs a custom message with the receiver's tuned frequency as the channel name.
+    /// Sends radio messages directly to the wearer only, not broadcast to nearby players.
+    /// Displays the receiver's tuned frequency as the channel name.
     /// </summary>
     private void OnRadioReceive(Entity<STRadioHeadsetComponent> ent, ref RadioReceiveEvent args)
     {
-        // Get the wearer (parent entity) and check if they're a player
         if (!TryComp(Transform(ent).ParentUid, out ActorComponent? actor))
             return;
 
-        // Get the frequency to display - use the receiver's tuned frequency
         var channelDisplay = TryComp<RadioStalkerComponent>(ent, out var stalkerComp) && !string.IsNullOrEmpty(stalkerComp.CurrentFrequency)
             ? Loc.GetString("st-radio-headset-frequency-display", ("frequency", stalkerComp.CurrentFrequency))
             : Loc.GetString("st-radio-headset-channel-default");
 
-        // Get the speaker name with any transforms applied
         var speakerName = GetTransformedSpeakerName(args.MessageSource, out var speechVerb);
 
-        // Get the speech verb prototype
         SpeechVerbPrototype speech;
         if (speechVerb != null && _prototype.TryIndex(speechVerb, out var verbProto))
             speech = verbProto;
         else
             speech = _chat.GetSpeechVerb(args.MessageSource, args.Message);
 
-        // Escape message content for safe display
         var content = FormattedMessage.EscapeText(args.Message);
 
-        // Build the formatted radio message with the dynamic frequency and custom headset color
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
             ("color", ent.Comp.ChatColor),
             ("fontType", speech.FontId),
@@ -163,7 +141,6 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
             ("name", speakerName),
             ("message", content));
 
-        // Create and send the chat message
         var chat = new ChatMessage(
             ChatChannel.Radio,
             args.Message,
@@ -175,9 +152,6 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         _netMan.ServerSendMessage(chatMsg, actor.PlayerSession.Channel);
     }
 
-    /// <summary>
-    /// Gets the transformed speaker name, applying any voice modifications.
-    /// </summary>
     private string GetTransformedSpeakerName(EntityUid source, out ProtoId<SpeechVerbPrototype>? speechVerb)
     {
         var evt = new TransformSpeakerNameEvent(source, MetaData(source).EntityName);
@@ -194,10 +168,7 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         if (!TryComp<RadioMicrophoneComponent>(ent, out var mic))
             return;
 
-        // Toggle mic state
-        var newMicState = !mic.Enabled;
-        _radioDevice.SetMicrophoneEnabled(ent, args.Performer, newMicState, true);
-
+        _radioDevice.SetMicrophoneEnabled(ent, args.Performer, !mic.Enabled, true);
         UpdateActionStates(ent);
         UpdateRadioUi(ent);
         args.Handled = true;
@@ -208,57 +179,35 @@ public sealed class STRadioHeadsetSystem : SharedSTRadioHeadsetSystem
         UpdateRadioUi(ent);
     }
 
-    /// <summary>
-    /// Called when the UI panel mic button is clicked.
-    /// Updates the microphone state and syncs action button states.
-    /// </summary>
     private void OnUiToggleMic(Entity<STRadioHeadsetComponent> ent, ref STRadioHeadsetToggleMicMessage args)
     {
         _radioDevice.SetMicrophoneEnabled(ent, args.Actor, args.Enabled, true);
         UpdateActionStates(ent);
     }
 
-    /// <summary>
-    /// Called when the user enters a frequency in the UI.
-    /// Validates the frequency format (must match "000.0" pattern) and updates the RadioStalkerComponent's CurrentFrequency.
-    /// Invalid frequencies are replaced with the default frequency.
-    /// </summary>
     private void OnUiSelectFrequency(Entity<STRadioHeadsetComponent> ent, ref STRadioHeadsetSelectFrequencyMessage args)
     {
         if (!TryComp<RadioStalkerComponent>(ent, out var stalkerComp))
             return;
 
-        // Validate and sanitize the frequency input
         var frequency = args.Frequency;
 
-        // Check if frequency is empty/whitespace or doesn't match the required pattern
         if (string.IsNullOrWhiteSpace(frequency) || !FrequencyPattern.IsMatch(frequency))
-        {
             frequency = STRadioHeadsetComponent.DefaultFrequency;
-        }
         else if (frequency.Length > MaxFrequencyLength)
-        {
             frequency = frequency[..MaxFrequencyLength];
-        }
 
         stalkerComp.CurrentFrequency = frequency;
         Dirty(ent, stalkerComp);
         UpdateRadioUi(ent);
     }
 
-    /// <summary>
-    /// Updates the toggle state of the action button to reflect current microphone status.
-    /// </summary>
     private void UpdateActionStates(Entity<STRadioHeadsetComponent> ent)
     {
         var micEnabled = TryComp<RadioMicrophoneComponent>(ent, out var mic) && mic.Enabled;
         _actions.SetToggled(ent.Comp.ToggleMicActionEntity, micEnabled);
     }
 
-    /// <summary>
-    /// Updates the radio UI panel state to reflect current mic status and frequency.
-    /// Called after action button toggles to sync the UI with the action button state.
-    /// </summary>
     private void UpdateRadioUi(EntityUid uid)
     {
         if (!TryComp<RadioStalkerComponent>(uid, out var stalkerComp))

--- a/Content.Shared/_Stalker_EN/Radio/STRadioHeadsetComponent.cs
+++ b/Content.Shared/_Stalker_EN/Radio/STRadioHeadsetComponent.cs
@@ -28,6 +28,11 @@ public sealed partial class STRadioHeadsetComponent : Component
     [DataField]
     public EntProtoId ToggleMicAction = "ActionSTRadioToggleMic";
 
-    [DataField, AutoNetworkedField, ViewVariables]
+    /// <summary>
+    /// Entity UID for the spawned toggle mic action.
+    /// Not networked or serialized - actions are recreated on MapInit and the action system
+    /// handles its own networking. This prevents stale UID serialization errors.
+    /// </summary>
+    [ViewVariables]
     public EntityUid? ToggleMicActionEntity;
 }


### PR DESCRIPTION
## What I changed

Fixed radio headset action button not appearing when loading from loadout.

**Root cause:** During loadout restore, `DeleteChildren()` calls `QueueDeleteEntity()` on the action entity created by MapInit. However, `QueueDeleteEntity()` only adds the entity to a deletion queue without changing its `LifeStage`. The existing `TerminatingOrDeleted()` check only looks at `LifeStage`, so it failed to detect queued-for-deletion actions.

**Fix:** Added `IsActionInvalid()` helper that checks both:
- `TerminatingOrDeleted()` - entity is being/has been deleted
- `EntityManager.IsQueuedForDeletion()` - entity is queued for deletion but not yet processing

## Changelog

author: @teecoding

- fix: Radio headset action button now appears correctly when loading from loadout

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
