### PR TITLE
fix(respawn): send Deny message when popup X button is clicked

### DIFF
--- a/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmEui.cs
+++ b/Content.Client/_Stalker_EN/RespawnConfirm/STRespawnConfirmEui.cs
@@ -9,22 +9,32 @@ namespace Content.Client._Stalker_EN.RespawnConfirm;
 public sealed class STRespawnConfirmEui : BaseEui
 {
     private readonly STRespawnConfirmWindow _window;
+    private bool _messageSent;
 
     public STRespawnConfirmEui()
     {
         _window = new STRespawnConfirmWindow();
+        _window.OnClose += OnWindowClosed;
 
         _window.DenyButton.OnPressed += _ =>
         {
+            _messageSent = true;
             SendMessage(new STRespawnConfirmMessage(STRespawnConfirmButton.Deny));
             _window.Close();
         };
 
         _window.AcceptButton.OnPressed += _ =>
         {
+            _messageSent = true;
             SendMessage(new STRespawnConfirmMessage(STRespawnConfirmButton.Accept));
             _window.Close();
         };
+    }
+
+    private void OnWindowClosed()
+    {
+        if (!_messageSent)
+            SendMessage(new STRespawnConfirmMessage(STRespawnConfirmButton.Deny));
     }
 
     public override void Opened()


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Fixed a bug where players could become stuck unable to respawn after closing the respawn confirmation popup using the X button.

**Root cause:** When the X button was clicked, no message was sent to the server. The server kept the session in `_openConfirms`, blocking any future popup attempts since the check at line 133 returns early if the session is already in the set.

**Fix:** Added an `OnClose` handler that sends a `Deny` message to the server when the window is closed without clicking Accept or Deny. A `_messageSent` flag prevents duplicate messages when closing via the buttons.

## Changelog

author: @teecoding 

- fix: Respawn popup can now be reopened after closing with the X button

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
