### PR TITLE
fix: prevent emission lightning in safe zones

### DIFF
--- a/Content.Server/_Stalker_EN/Emission/EmissionLightningSpawnerComponent.cs
+++ b/Content.Server/_Stalker_EN/Emission/EmissionLightningSpawnerComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server._Stalker_EN.Emission;
 /// <summary>
 ///     Periodically spawns lightning around this.
 /// </summary>
-[RegisterComponent, Access([typeof(EmissionLightningSystem), typeof(EmissionEventRuleSystem)])]
+[RegisterComponent, Access([typeof(EmissionLightningSystem), typeof(EmissionEventRuleSystem), typeof(EmissionSafeZoneSystem)])]
 [AutoGenerateComponentPause]
 public sealed partial class EmissionLightningSpawnerComponent : Component
 {

--- a/Content.Server/_Stalker_EN/Emission/EmissionSafeZoneSystem.cs
+++ b/Content.Server/_Stalker_EN/Emission/EmissionSafeZoneSystem.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Server._Stalker.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+
+namespace Content.Server._Stalker_EN.Emission;
+
+/// <summary>
+/// Manages lightning spawner components on entities entering/exiting safe zones during emissions.
+/// Ensures entities in safe zones are protected from emission lightning strikes.
+/// </summary>
+public sealed class EmissionSafeZoneSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StalkerSafeZoneComponent, ComponentStartup>(OnSafeZoneEnter);
+        SubscribeLocalEvent<StalkerSafeZoneComponent, ComponentRemove>(OnSafeZoneExit);
+    }
+
+    private void OnSafeZoneEnter(Entity<StalkerSafeZoneComponent> entity, ref ComponentStartup args)
+    {
+        RemComp<EmissionLightningSpawnerComponent>(entity);
+    }
+
+    private void OnSafeZoneExit(Entity<StalkerSafeZoneComponent> entity, ref ComponentRemove args)
+    {
+        if (!TryGetActiveEmissionInStage2(out var emissionComp))
+            return;
+
+        if (HasComp<EmissionLightningSpawnerComponent>(entity))
+            return;
+
+        if (emissionComp.LightningEffectProtoId is not { } lightningProtoId)
+            return;
+
+        var spawnerComp = EnsureComp<EmissionLightningSpawnerComponent>(entity);
+        spawnerComp.SpawnRadius = emissionComp.LightningSpawnRadius;
+        spawnerComp.LightningIntervalRange = emissionComp.LightningIntervalRange;
+        spawnerComp.LightningEffectProtoId = lightningProtoId;
+    }
+
+    private bool TryGetActiveEmissionInStage2([NotNullWhen(true)] out EmissionEventRuleComponent? emissionComp)
+    {
+        emissionComp = null;
+
+        var query = EntityQueryEnumerator<ActiveGameRuleComponent, EmissionEventRuleComponent>();
+        while (query.MoveNext(out _, out _, out var emission))
+        {
+            if (emission.Stage == EmissionStage.Stage2)
+            {
+                emissionComp = emission;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Fixed emission lightning spawning near players who are inside safe zones (shelters). Previously, lightning from PR #364 would spawn near all players with `BlowoutTargetComponent` during Stage 2 emissions, ignoring `StalkerSafeZoneComponent` protection.

**Solution:** Player-based protection with dynamic enter/exit handling:
1. **Initial check**: Skip players with `StalkerSafeZoneComponent` when adding `EmissionLightningSpawnerComponent` during Stage 2 transition
2. **Enter safe zone**: Remove `EmissionLightningSpawnerComponent` when player enters a safe zone
3. **Exit safe zone**: Re-add `EmissionLightningSpawnerComponent` when player exits a safe zone (only if emission is active in Stage 2)


## Changelog

author: @teecoding

- fix: Prevent emission lightning from spawning near players in safe zones

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
