### PR TITLE
fix: day/night cycle stuck on nighttime after emission ends mid-round

### DIFF
--- a/Content.Server/_Stalker_EN/Emission/EmissionEventRuleSystem.cs
+++ b/Content.Server/_Stalker_EN/Emission/EmissionEventRuleSystem.cs
@@ -54,7 +54,14 @@ public sealed class EmissionEventRuleSystem : StationEventSystem<EmissionEventRu
     protected override void Ended(EntityUid uid, EmissionEventRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
     {
         base.Ended(uid, component, gameRule, args);
-        // Ambient light is cleared at stage 3 (T+330), not at event end
+
+        // Clean up lightning spawners (handles mid-round admin cancel during Stage 2)
+        var lightningQuery = EntityQueryEnumerator<EmissionLightningSpawnerComponent>();
+        while (lightningQuery.MoveNext(out var targetUid, out var spawnerComponent))
+            RemCompDeferred(targetUid, spawnerComponent);
+
+        // Always restore day cycle - idempotent, safe even if stage 3 already cleaned up
+        ClearAmbientLightColor();
     }
 
     protected override void ActiveTick(EntityUid uid, EmissionEventRuleComponent component, GameRuleComponent gameRule, float frameTime)

--- a/Content.Server/_Stalker_EN/MapLightSimulation/MapDayRoundResetSystem.cs
+++ b/Content.Server/_Stalker_EN/MapLightSimulation/MapDayRoundResetSystem.cs
@@ -1,0 +1,25 @@
+using Content.Server._Stalker.MapLightSimulation;
+using Content.Shared.GameTicking;
+
+namespace Content.Server._Stalker_EN.MapLightSimulation;
+
+/// <summary>
+/// Resets the day/night cycle on round restart as a safety net.
+/// Prevents <see cref="MapDaySystem"/>._enabled from being stuck at false
+/// if any system failed to re-enable it before the round ended.
+/// </summary>
+public sealed class MapDayRoundResetSystem : EntitySystem
+{
+    [Dependency] private readonly MapDaySystem _mapDay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
+    {
+        _mapDay.SetEnabled(true);
+    }
+}


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Fixed the day/night cycle getting permanently stuck on nighttime after a round ends during an active emission event. The root cause: `MapDaySystem._enabled` is a system-level field that persists across rounds. `EmissionEventRuleSystem` disables it when the red hue starts (Stage 1) but only re-enables it during the Stage 2-to-Stage 3 transition. If a round ends mid-emission, `_enabled` stays `false` for all subsequent rounds.

1. **`EmissionEventRuleSystem.Ended()` cleanup** - When the game rule ends (round end or admin cancel), clean up lightning spawners and call `ClearAmbientLightColor()` to restore the day cycle. Both operations are idempotent, so they're safe even if Stage 3 already ran its cleanup.

2. **`MapDayRoundResetSystem` safety net** - A new system in `_Stalker_EN/` that subscribes to `RoundRestartCleanupEvent` and calls `_mapDay.SetEnabled(true)`. This guarantees the day cycle is restored on every round restart regardless of what happened in the previous round.

## Changelog

author: @teecoding

- fix: Day/night cycle no longer gets stuck on nighttime after round ends during an emission

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
