### PR TITLE
fix(sera-bomb): allow self-detonate when crit or cuffed

### DIFF
--- a/Resources/Prototypes/_Stalker/Actions/sera_suicide.yml
+++ b/Resources/Prototypes/_Stalker/Actions/sera_suicide.yml
@@ -5,7 +5,7 @@
   description: Подрыв вашего кпк с гарантированным раздвоением вашего Я во имя Сына Звезды на целых две части!
   components:
   - type: InstantAction
-    checkCanInteract: true
+    checkCanInteract: false
     checkConsciousness: false
     itemIconStyle: BigAction
     priority: -20


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

**Fixed Sera Bomb unusable when crit or cuffed.** The action prototype had `checkConsciousness: false` to allow crit use, but `checkCanInteract: true` re-introduced both blocks — crit via `CanInteract()` → `CanConsciouslyPerformAction()`, and cuffs via `InteractionAttemptEvent` → `CuffableSystem`. Set `checkCanInteract: false` so the self-destruct works regardless of mob state or cuff state.

## Changelog

author: @teecoding

- fix: Monolith Sera Bomb can now be activated while in crit or handcuffed

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
