### PR TITLE
feat: add quick equip bolt keybind (N) with inventory search and Stalker 14 keybind UI section

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -71,6 +71,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
             human.AddFunction(ContentKeyFunctions.SmartEquipOuterClothing); // Stalker-Changes-UI
             human.AddFunction(ContentKeyFunctions.Lay); // Stalker-Changes-UI
+            human.AddFunction(ContentKeyFunctions.STQuickEquipBolt); // Stalker-Changes-UI
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
             human.AddFunction(ContentKeyFunctions.OpenBackpack);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -189,8 +189,6 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
             AddButton(ContentKeyFunctions.OpenBackpack);
-            AddButton(ContentKeyFunctions.SmartEquipOuterClothing); // Stalker-Changes-UI
-            AddButton(ContentKeyFunctions.Lay); // Stalker-Changes-UI
             AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);
             AddButton(ContentKeyFunctions.TryPullObject);
@@ -266,6 +264,13 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(EngineKeyFunctions.ShowDebugMonitors);
             AddButton(EngineKeyFunctions.HideUI);
             AddButton(ContentKeyFunctions.InspectEntity);
+
+            // stalker-changes
+            AddHeader("ui-options-header-stalker");
+            AddButton(ContentKeyFunctions.SmartEquipOuterClothing);
+            AddButton(ContentKeyFunctions.Lay);
+            AddButton(ContentKeyFunctions.STQuickEquipBolt);
+            // stalker-changes-end
 
             foreach (var control in _keyControls.Values)
             {

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -35,6 +35,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipOuterClothing = "SmartEquipOuterClothing"; // Stalker-Changes-UI
         public static readonly BoundKeyFunction Lay = "Lay"; // Stalker-Changes-UI
+        public static readonly BoundKeyFunction STQuickEquipBolt = "STQuickEquipBolt"; // Stalker-Changes-UI
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";

--- a/Content.Shared/_Stalker_EN/QuickEquipBolt/STQuickEquipBoltSystem.cs
+++ b/Content.Shared/_Stalker_EN/QuickEquipBolt/STQuickEquipBoltSystem.cs
@@ -1,0 +1,150 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Input;
+using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
+using Robust.Shared.Containers;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Stalker_EN.QuickEquipBolt;
+
+/// <summary>
+/// Handles the quick equip bolt keybind. Searches the player's inventory (including nested storage)
+/// for an entity with the STBolt tag and picks it up into an empty hand.
+/// </summary>
+public sealed class STQuickEquipBoltSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    private static readonly ProtoId<TagPrototype> BoltTag = "STBolt";
+
+    /// <summary>
+    /// Defensive guard against pathological nesting; circular refs are impossible in the engine
+    /// but this bounds worst-case iteration.
+    /// </summary>
+    private const int MaxSearchDepth = 4;
+
+    /// <summary>
+    /// Belt is first because bolt bags are typically stored there.
+    /// </summary>
+    private static readonly string[] SlotPriority = { "belt", "pocket1", "pocket2", "back", "suitstorage", "id" };
+
+    private static readonly HashSet<string> PrioritySlotSet = new(SlotPriority);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.STQuickEquipBolt,
+                InputCmdHandler.FromDelegate(HandleQuickEquipBolt, handle: false, outsidePrediction: false))
+            .Register<STQuickEquipBoltSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        CommandBinds.Unregister<STQuickEquipBoltSystem>();
+    }
+
+    private void HandleQuickEquipBolt(ICommonSession? session)
+    {
+        if (session?.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHand == null)
+            return;
+
+        if (!_actionBlocker.CanInteract(uid, null))
+            return;
+
+        if (!_hands.TryGetEmptyHand(uid, out _, hands))
+        {
+            _popup.PopupClient(Loc.GetString("st-quick-equip-bolt-hands-full"), uid, uid);
+            return;
+        }
+
+        if (!TryFindBolt(uid, out var boltUid))
+        {
+            _popup.PopupClient(Loc.GetString("st-quick-equip-bolt-none-found"), uid, uid);
+            return;
+        }
+
+        _hands.TryPickupAnyHand(uid, boltUid.Value, checkActionBlocker: false, handsComp: hands);
+    }
+
+    /// <summary>
+    /// Searches the player's inventory slots and their nested containers for an entity with the STBolt tag.
+    /// Priority slots are checked first, then remaining slots.
+    /// </summary>
+    private bool TryFindBolt(EntityUid uid, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EntityUid? found)
+    {
+        found = null;
+
+        if (!_inventory.TryGetSlots(uid, out var slotDefs))
+            return false;
+
+        foreach (var slotName in SlotPriority)
+        {
+            if (!_inventory.TryGetSlotEntity(uid, slotName, out var slotEntity))
+                continue;
+
+            if (TryFindBoltInEntity(slotEntity.Value, out found, 0))
+                return true;
+        }
+
+        foreach (var slotDef in slotDefs)
+        {
+            if (PrioritySlotSet.Contains(slotDef.Name))
+                continue;
+
+            if (!_inventory.TryGetSlotEntity(uid, slotDef.Name, out var slotEntity))
+                continue;
+
+            if (TryFindBoltInEntity(slotEntity.Value, out found, 0))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if the entity itself has the STBolt tag, or recursively searches its containers.
+    /// </summary>
+    private bool TryFindBoltInEntity(EntityUid entity, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EntityUid? found, int depth)
+    {
+        found = null;
+
+        if (_tag.HasTag(entity, BoltTag))
+        {
+            found = entity;
+            return true;
+        }
+
+        if (depth >= MaxSearchDepth)
+            return false;
+
+        if (!TryComp<ContainerManagerComponent>(entity, out var containerManager))
+            return false;
+
+        foreach (var container in _container.GetAllContainers(entity, containerManager))
+        {
+            foreach (var contained in container.ContainedEntities)
+            {
+                if (TryFindBoltInEntity(contained, out found, depth + 1))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Resources/Locale/en-US/_stalker/ui-options.ftl
+++ b/Resources/Locale/en-US/_stalker/ui-options.ftl
@@ -1,2 +1,4 @@
+ui-options-header-stalker = Stalker 14
 ui-options-function-smart-equip-outer-clothing = Smart equip outer clothing
 ui-options-function-lay = Lie down
+ui-options-function-st-quick-equip-bolt = Quick equip bolt

--- a/Resources/Locale/en-US/_stalker_en/quick-equip-bolt.ftl
+++ b/Resources/Locale/en-US/_stalker_en/quick-equip-bolt.ftl
@@ -1,0 +1,2 @@
+st-quick-equip-bolt-hands-full = Your hands are full!
+st-quick-equip-bolt-none-found = No bolts found!

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -592,4 +592,7 @@ binds:
   type: State
   key: R
   mod1: Shift
+- function: STQuickEquipBolt
+  type: State
+  key: N
   # stalker-changes-ends


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added a **Quick Equip Bolt** keybind (`N` by default, rebindable) that instantly pulls an STBolt-tagged entity from anywhere in the player's inventory.

### Keybind UI
- Created a dedicated **"Stalker 14"** section in the keybind settings
- Moved existing Stalker keybinds (Smart equip outer clothing, Lie down) from "Advanced Interaction" into the new section
- Added the new Quick equip bolt keybind to the section

## Changelog

author: @teecoding

- add: Press N to quickly pull a bolt from your bags into your hand
- tweak: all Stalker keybinds are now grouped together and rebindable

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
