### PR TITLE
feat: relay critical emotes (gasp, deathgasp) over stalker radio headset

### DIFF
--- a/Content.Server/_Stalker_EN/Radio/STRadioEmoteRelaySystem.cs
+++ b/Content.Server/_Stalker_EN/Radio/STRadioEmoteRelaySystem.cs
@@ -1,0 +1,57 @@
+using Content.Server.Chat.Systems;
+using Content.Server.Radio.Components;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared._Stalker_EN.Radio;
+using Content.Shared.Inventory;
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Stalker_EN.Radio;
+
+/// <summary>
+/// Relays distress emotes (gasps, deathgasps) over the Stalker radio headset
+/// when the player's microphone is enabled, allowing teammates on the same
+/// frequency to hear critical condition sounds.
+/// </summary>
+public sealed class STRadioEmoteRelaySystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly RadioSystem _radio = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private static readonly HashSet<string> RelayedEmotes = new()
+    {
+        "Gasp",
+        "DefaultDeathgasp",
+    };
+
+    private static readonly ProtoId<RadioChannelPrototype> StalkerInternalChannel = "StalkerInternal";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<InventoryComponent, EmoteEvent>(OnEmote);
+    }
+
+    private void OnEmote(Entity<InventoryComponent> ent, ref EmoteEvent args)
+    {
+        if (!RelayedEmotes.Contains(args.Emote.ID))
+            return;
+
+        if (!_inventory.TryGetSlotEntity(ent, "ears", out var headsetUid, ent.Comp))
+            return;
+
+        if (!HasComp<STRadioHeadsetComponent>(headsetUid))
+            return;
+
+        if (!TryComp<RadioMicrophoneComponent>(headsetUid, out var mic) || !mic.Enabled)
+            return;
+
+        if (args.Emote.ChatMessages.Count == 0)
+            return;
+
+        var emoteText = Loc.GetString(_random.Pick(args.Emote.ChatMessages), ("entity", ent.Owner));
+        _radio.SendRadioMessage(ent, emoteText, StalkerInternalChannel, headsetUid.Value);
+    }
+}


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added a **Radio Emote Relay** system that transmits critical-condition emotes (gasps, deathgasps) over the Stalker radio headset when the player's mic is enabled. Teammates on the same frequency will see the distress sounds in their radio chat.

## Changelog

author: @teecoding

- add: Critical condition gasps and deathgasps are now relayed over the Stalker radio headset when mic is enabled

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
