### PR TITLE
feat: add fire patting mechanic to extinguish burning entities

### DIFF
--- a/Content.Client/_Stalker_EN/FirePat/STFirePatSystem.cs
+++ b/Content.Client/_Stalker_EN/FirePat/STFirePatSystem.cs
@@ -1,0 +1,9 @@
+using Content.Shared._Stalker_EN.FirePat;
+
+namespace Content.Client._Stalker_EN.FirePat;
+
+/// <summary>
+/// Client stub so the shared base system runs on the client and suppresses
+/// the predicted hug popup when patting a burning entity.
+/// </summary>
+public sealed class STFirePatSystem : SharedSTFirePatSystem;

--- a/Content.Server/_Stalker_EN/FirePat/STFirePatSystem.cs
+++ b/Content.Server/_Stalker_EN/FirePat/STFirePatSystem.cs
@@ -1,0 +1,64 @@
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Shared._Stalker_EN.FirePat;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Popups;
+using Content.Shared.Whitelist;
+using Robust.Server.Audio;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Stalker_EN.FirePat;
+
+/// <summary>
+/// Server-side fire patting: adjusts fire stacks, shows popups, plays sound.
+/// Hug suppression is handled by the shared base <see cref="SharedSTFirePatSystem"/>.
+/// </summary>
+public sealed class STFirePatSystem : SharedSTFirePatSystem
+{
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly FlammableSystem _flammable = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    protected override void HandleFirePat(EntityUid user, EntityUid target)
+    {
+        if (!TryComp<STFirePatterComponent>(user, out var patter))
+            return;
+
+        if (!TryComp<FlammableComponent>(target, out var flammable) || !flammable.OnFire)
+            return;
+
+        var curTime = _timing.CurTime;
+        if (curTime < patter.LastPatTime + patter.Cooldown)
+            return;
+
+        if (_whitelist.IsBlacklistPass(patter.Blacklist, target))
+            return;
+
+        patter.LastPatTime = curTime;
+
+        _flammable.AdjustFireStacks(target, patter.Stacks, flammable);
+
+        var targetName = Identity.Name(target, EntityManager, user);
+        var userName = Identity.Name(user, EntityManager, target);
+
+        _popup.PopupEntity(
+            Loc.GetString("st-fire-pat-performer", ("target", targetName)),
+            target, user);
+
+        _popup.PopupEntity(
+            Loc.GetString("st-fire-pat-target", ("user", userName)),
+            target, target);
+
+        _popup.PopupEntity(
+            Loc.GetString("st-fire-pat-others", ("user", userName), ("target", targetName)),
+            target,
+            Filter.PvsExcept(target).RemovePlayerByAttachedEntity(user),
+            true);
+
+        if (patter.Sound != null)
+            _audio.PlayPvs(patter.Sound, target);
+    }
+}

--- a/Content.Shared/_Stalker_EN/FirePat/STFirePattableComponent.cs
+++ b/Content.Shared/_Stalker_EN/FirePat/STFirePattableComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.FirePat;
+
+/// <summary>
+/// Marker component for entities that can be patted to extinguish fire.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class STFirePattableComponent : Component;

--- a/Content.Shared/_Stalker_EN/FirePat/STFirePatterComponent.cs
+++ b/Content.Shared/_Stalker_EN/FirePat/STFirePatterComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.FirePat;
+
+/// <summary>
+/// Component for entities that can pat burning entities to reduce their fire stacks.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+public sealed partial class STFirePatterComponent : Component
+{
+    /// <summary>
+    /// Fire stacks added per pat. Negative values reduce fire stacks.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Stacks = -2f;
+
+    /// <summary>
+    /// Minimum time between pats.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// When this entity last patted someone (absolute game time).
+    /// </summary>
+    [ViewVariables, AutoPausedField]
+    public TimeSpan LastPatTime;
+
+    /// <summary>
+    /// Sound played when patting a burning entity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? Sound = new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg");
+
+    /// <summary>
+    /// Entities matching this blacklist cannot be patted.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Blacklist;
+}

--- a/Content.Shared/_Stalker_EN/FirePat/SharedSTFirePatSystem.cs
+++ b/Content.Shared/_Stalker_EN/FirePat/SharedSTFirePatSystem.cs
@@ -1,0 +1,47 @@
+using Content.Shared.Atmos;
+using Content.Shared.Interaction;
+
+namespace Content.Shared._Stalker_EN.FirePat;
+
+/// <summary>
+/// Suppresses the interaction popup (hug) on both client and server when patting
+/// a burning entity, then delegates actual fire patting to the server override.
+/// Must be subclassed on both client and server so the handler runs on both sides.
+/// </summary>
+public abstract class SharedSTFirePatSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // InteractionPopupSystem is shared and uses prediction — it sets Handled = true
+        // on both client and server for alive mobs. We must run before it on both sides
+        // to suppress the hug popup when the target is on fire.
+        SubscribeLocalEvent<STFirePattableComponent, InteractHandEvent>(OnInteractHand,
+            before: [typeof(InteractionPopupSystem)]);
+    }
+
+    private void OnInteractHand(Entity<STFirePattableComponent> entity, ref InteractHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (args.User == args.Target)
+            return;
+
+        if (!HasComp<STFirePatterComponent>(args.User))
+            return;
+
+        if (!_appearance.TryGetData<bool>(args.Target, FireVisuals.OnFire, out var onFire) || !onFire)
+            return;
+
+        args.Handled = true;
+        HandleFirePat(args.User, args.Target);
+    }
+
+    protected virtual void HandleFirePat(EntityUid user, EntityUid target)
+    {
+    }
+}

--- a/Resources/Locale/en-US/_Stalker_EN/fire-pat.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/fire-pat.ftl
@@ -1,0 +1,3 @@
+st-fire-pat-performer = You pat {$target} trying to put out the fire!
+st-fire-pat-target = {$user} pats you trying to put out the fire!
+st-fire-pat-others = {$user} pats {$target} trying to put out the fire!

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -226,6 +226,7 @@
   - MobRespirator
   - MobAtmosStandard
   - MobFlammable
+  - MobFirePat # stalker-changes - fire patting
   - BaseMobSpecies
   id: BaseMobSpeciesOrganic
   abstract: true

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/base.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/base.yml
@@ -4,6 +4,7 @@
   - MobWeight
   - MobStaminaDamageable
   - MobLay
+  - MobFirePat # stalker-changes - fire patting
   id: BaseMobMutant
   save: false
   abstract: true
@@ -183,6 +184,7 @@
     - MobWeight
     - MobStaminaDamageable
     - MobLay
+    - MobFirePat # stalker-changes - fire patting
   id: STBaseMobMutant
   save: false
   abstract: true

--- a/Resources/Prototypes/_Stalker_EN/Entities/Mobs/fire_pat.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Mobs/fire_pat.yml
@@ -1,0 +1,9 @@
+- type: entity
+  save: false
+  id: MobFirePat
+  abstract: true
+  components:
+  - type: STFirePattable
+  - type: STFirePatter
+    stacks: -2
+    cooldown: 1


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added a **Fire Patting** mechanic ported from RMC-14: players can interact with an empty hand on a burning entity to reduce its fire stacks. Requires multiple pats to fully extinguish.

## Changelog

author: @teecoding

- add: Players can pat burning entities with an empty hand to reduce fire stacks

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
