### PR TITLE
feat(shop): filter low-value items from sell tab via configurable Min SellPrice threshold

### DIFF
--- a/Content.Server/_Stalker/Shop/ShopSystem.cs
+++ b/Content.Server/_Stalker/Shop/ShopSystem.cs
@@ -60,7 +60,7 @@ public sealed partial class ShopSystem : SharedShopSystem
         SubscribeLocalEvent<StorageAfterInsertItemIntoLocationEvent>(OnAfterInsert);
 
         _sawmill = Logger.GetSawmill("shops");
-        
+
         InitializeSponsors();
     }
 
@@ -179,10 +179,10 @@ public sealed partial class ShopSystem : SharedShopSystem
         var categories = component.ShopCategories;
 
         #region Sponsors-Stuff
-        
+
         if (!TryComp<ActorComponent>(user, out var actor))
             return;
-        
+
         // TODO: GetSponsorCategories/GetContributorCategories/GetPersonalCategories results is not being cached like
         // component.ShopCategories, due this little shit, idk how fast it'd work. But im sure this should be rewrited. Im too lazy now...
         var sponsorCategory = GetSponsorCategories(actor.PlayerSession.UserId, component);
@@ -191,7 +191,7 @@ public sealed partial class ShopSystem : SharedShopSystem
         #endregion
 
         var userItems = GetContainerItemsWithoutMoney(user.Value, component);
-        var userListings = GetListingData(userItems, component, proto.SellingItems);
+        var userListings = GetListingData(userItems, component, proto.SellingItems, proto.MinSellPrice); //stalker-14-en change
 
         var money = sellBuyBalance ?? GetMoneyFromList(GetContainersElements(user.Value), component);
         component.CurrentBalance = money;
@@ -349,8 +349,8 @@ public sealed partial class ShopSystem : SharedShopSystem
 
         return result;
     }
-    
-    private List<ListingData> GetListingData(List<EntityUid> items, ShopComponent component, Dictionary<string, int> sellItems)
+
+    private List<ListingData> GetListingData(List<EntityUid> items, ShopComponent component, Dictionary<string, int> sellItems, int minSellPrice = 5)
     {
         var result = new List<ListingData>();
         foreach (var item in items)
@@ -390,6 +390,10 @@ public sealed partial class ShopSystem : SharedShopSystem
                 ProductEntity = meta.EntityPrototype?.ID,
                 Count = 1 // Initialize count to 1 for the first item
             };
+
+            // stalker-changes-en: skip items below minimum sell price
+            if (minSellPrice > 0 && listing.OriginalCost.Values.Sum() < minSellPrice)
+                continue;
 
             result.Add(listing);
         }

--- a/Content.Shared/_Stalker/Shop/Prototypes/ShopPresetPrototype.cs
+++ b/Content.Shared/_Stalker/Shop/Prototypes/ShopPresetPrototype.cs
@@ -29,6 +29,12 @@ public sealed class ShopPresetPrototype : IPrototype
     /// </summary>
     [DataField("itemsForSale")]
     public Dictionary<string, int> SellingItems = new();
+
+    /// <summary>
+    /// Minimum sell price to show an item in the sell tab. Items below this threshold are hidden.
+    /// </summary>
+    [DataField]
+    public int MinSellPrice = 5; // stalker-changes-en
 }
 [DataDefinition, Serializable, NetSerializable]
 public sealed partial class CategoryInfo


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added a **minimum sell price filter** to the shop so low-value junk items no longer clutter the sell tab.

## Changelog

author: @teecoding

- tweak: Shop sell tab now hides items worth less than 5 roubles

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
