### PR TITLE
fix: replace base Tourniquet with STTourniquet in Stalker loot tables

### DIFF
--- a/Resources/Prototypes/_Stalker/Caches/cache/T1.yml
+++ b/Resources/Prototypes/_Stalker/Caches/cache/T1.yml
@@ -27,7 +27,7 @@
           prob: 0.2
         - id: STOintment
           prob: 0.2
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.03
         - id: antiradpill
           prob: 0.03

--- a/Resources/Prototypes/_Stalker/Caches/cache/T2.yml
+++ b/Resources/Prototypes/_Stalker/Caches/cache/T2.yml
@@ -77,7 +77,7 @@
           prob: 0.25
         - id: STOintment
           prob: 0.25
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.06
         - id: antiradpill
           prob: 0.06

--- a/Resources/Prototypes/_Stalker/Caches/cache/T3.yml
+++ b/Resources/Prototypes/_Stalker/Caches/cache/T3.yml
@@ -69,7 +69,7 @@
           prob: 0.3
         - id: STOintment
           prob: 0.3
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.09
         - id: antiradpill
           prob: 0.09

--- a/Resources/Prototypes/_Stalker/Caches/cache/T4.yml
+++ b/Resources/Prototypes/_Stalker/Caches/cache/T4.yml
@@ -53,7 +53,7 @@
           prob: 0.35
         - id: STOintment
           prob: 0.35
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.12
         - id: antiradpill
           prob: 0.12

--- a/Resources/Prototypes/_Stalker/Caches/cache/T5.yml
+++ b/Resources/Prototypes/_Stalker/Caches/cache/T5.yml
@@ -59,7 +59,7 @@
           prob: 0.4
         - id: STOintment
           prob: 0.4
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.15
         - id: antiradpill
           prob: 0.15

--- a/Resources/Prototypes/_Stalker/Caches/hidden_caches/T1.yml
+++ b/Resources/Prototypes/_Stalker/Caches/hidden_caches/T1.yml
@@ -65,7 +65,7 @@
           prob: 0.2
         - id: STOintment
           prob: 0.2
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.05
         - id: antiradpill
           prob: 0.05

--- a/Resources/Prototypes/_Stalker/Caches/hidden_caches/T2.yml
+++ b/Resources/Prototypes/_Stalker/Caches/hidden_caches/T2.yml
@@ -107,7 +107,7 @@
           prob: 0.25
         - id: STOintment
           prob: 0.25
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.1
         - id: antiradpill
           prob: 0.1

--- a/Resources/Prototypes/_Stalker/Caches/hidden_caches/T3.yml
+++ b/Resources/Prototypes/_Stalker/Caches/hidden_caches/T3.yml
@@ -163,7 +163,7 @@
           prob: 0.3
         - id: STOintment
           prob: 0.3
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.15
         - id: antiradpill
           prob: 0.15

--- a/Resources/Prototypes/_Stalker/Caches/hidden_caches/T4.yml
+++ b/Resources/Prototypes/_Stalker/Caches/hidden_caches/T4.yml
@@ -233,7 +233,7 @@
           prob: 0.35
         - id: STOintment
           prob: 0.35
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.2
         - id: antiradpill
           prob: 0.2

--- a/Resources/Prototypes/_Stalker/Caches/hidden_caches/T5.yml
+++ b/Resources/Prototypes/_Stalker/Caches/hidden_caches/T5.yml
@@ -303,7 +303,7 @@
           prob: 0.4
         - id: STOintment
           prob: 0.4
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.25
         - id: antiradpill
           prob: 0.25

--- a/Resources/Prototypes/_Stalker/Caches/trash/T1.yml
+++ b/Resources/Prototypes/_Stalker/Caches/trash/T1.yml
@@ -42,7 +42,7 @@
           prob: 0.2
         - id: STOintment
           prob: 0.2
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.02
         - id: antiradpill
           prob: 0.02

--- a/Resources/Prototypes/_Stalker/Caches/trash/T2.yml
+++ b/Resources/Prototypes/_Stalker/Caches/trash/T2.yml
@@ -42,7 +42,7 @@
           prob: 0.25
         - id: STOintment
           prob: 0.25
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.04
         - id: antiradpill
           prob: 0.04

--- a/Resources/Prototypes/_Stalker/Caches/trash/T3.yml
+++ b/Resources/Prototypes/_Stalker/Caches/trash/T3.yml
@@ -42,7 +42,7 @@
           prob: 0.3
         - id: STOintment
           prob: 0.3
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.06
         - id: antiradpill
           prob: 0.06

--- a/Resources/Prototypes/_Stalker/Caches/trash/T4.yml
+++ b/Resources/Prototypes/_Stalker/Caches/trash/T4.yml
@@ -70,7 +70,7 @@
           prob: 0.35
         - id: STOintment
           prob: 0.35
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.08
         - id: antiradpill
           prob: 0.08

--- a/Resources/Prototypes/_Stalker/Caches/trash/T5.yml
+++ b/Resources/Prototypes/_Stalker/Caches/trash/T5.yml
@@ -70,7 +70,7 @@
           prob: 0.4
         - id: STOintment
           prob: 0.4
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.1
         - id: antiradpill
           prob: 0.1

--- a/Resources/Prototypes/_Stalker/Caches/underground_storage/underground_storage.yml
+++ b/Resources/Prototypes/_Stalker/Caches/underground_storage/underground_storage.yml
@@ -88,7 +88,7 @@
           prob: 0.2
         - id: STOintment
           prob: 0.2
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
           prob: 0.02
         - id: antiradpill
           prob: 0.02

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
@@ -698,7 +698,7 @@
         - id: MedkitAI2
         - id: MedkitAI2
         - id: Bloodpack
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
       sound:
         path: /Audio/Effects/unwrap.ogg
 
@@ -734,8 +734,8 @@
         - id: Bloodpack
         - id: Bloodpack
         - id: Bloodpack
-        - id: Tourniquet
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
+        - id: STTourniquet # stalker-14-en
       sound:
         path: /Audio/Effects/unwrap.ogg
 
@@ -1073,9 +1073,9 @@
         - id: MedkitMilitary
         - id: Gauze
         - id: Gauze
-        - id: Tourniquet
-        - id: Tourniquet
-        - id: Tourniquet
+        - id: STTourniquet # stalker-14-en
+        - id: STTourniquet # stalker-14-en
+        - id: STTourniquet # stalker-14-en
         - id: FlashlightSeclite
         - id: PowerCellHyper
         - id: PowerCellHyper


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Replaced all instances of the base SS14 `Tourniquet` with `STTourniquet` across Stalker loot tables (caches, hidden caches, trash, underground storage, and crates).

## Changelog
author: @teecoding

- fix: Tourniquets found in stashes and crates now properly stop bleeding

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
