### PR TITLE
fix: make MinSellPrice opt-in (default 0) to stop hiding items in non-rouble shops

### DIFF
--- a/Content.Server/_Stalker/Shop/ShopSystem.cs
+++ b/Content.Server/_Stalker/Shop/ShopSystem.cs
@@ -359,7 +359,7 @@ public sealed partial class ShopSystem : SharedShopSystem
         return result;
     }
 
-    private List<ListingData> GetListingData(List<EntityUid> items, ShopComponent component, Dictionary<string, int> sellItems, int minSellPrice = 5)
+    private List<ListingData> GetListingData(List<EntityUid> items, ShopComponent component, Dictionary<string, int> sellItems, int minSellPrice = 0)
     {
         var result = new List<ListingData>();
         foreach (var item in items)

--- a/Content.Shared/_Stalker/Shop/Prototypes/ShopPresetPrototype.cs
+++ b/Content.Shared/_Stalker/Shop/Prototypes/ShopPresetPrototype.cs
@@ -34,7 +34,7 @@ public sealed class ShopPresetPrototype : IPrototype
     /// Minimum sell price to show an item in the sell tab. Items below this threshold are hidden.
     /// </summary>
     [DataField]
-    public int MinSellPrice = 5; // stalker-changes-en
+    public int MinSellPrice; // stalker-changes-en
 }
 [DataDefinition, Serializable, NetSerializable]
 public sealed partial class CategoryInfo

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Decoration/Seasonal/Vendor.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Decoration/Seasonal/Vendor.yml
@@ -18,6 +18,7 @@
 
 - type: shopPreset
   id: SantaPreset
+  minSellPrice: 5
   itemsForSale:
     PresentTrash: 10
   categories:

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/bandits.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/bandits.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: BandsShopPresetEN # Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 310

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: ClearSkyShopPresetEN # Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 540

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/dolg.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/dolg.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: DolgShopPresetEN # Mutant parts 1.5x Barman - Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     #Boars -------- Health * T
     MutantPartBoarHoof: 275 # T1

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcResearchInstituteEN # 0x
+  minSellPrice: 5
   categories:
     - name: shop-category-weapons
       priority: 1

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: FreedomShopPresetEN # Artifacts 1.5x Barman - Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 810

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/journalist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/journalist.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: JournalistShopPreset # 0x
+  minSellPrice: 5
   categories:
     - name: shop-category-weapons
       priority: 1

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/merc.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/merc.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: MercShopPresetEN # Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 400

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/militaries.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/militaries.yml
@@ -49,6 +49,7 @@
 
 - type: shopPreset
   id: VoenstalShopPresetEN # Voenstals
+  minSellPrice: 5
   itemsForSale:
     TradeBox: 1
   categories:
@@ -334,6 +335,7 @@
 
 - type: shopPreset
   id: OKSOPShopPresetEN # OKSOP REWORK IN-PROGRESS
+  minSellPrice: 5
   itemsForSale:
     FoodTinMRETrash: 0
     FoodTinPeachesTrash: 0
@@ -578,6 +580,7 @@
 
 - type: shopPreset
   id: OKSOPOfficerShopPresetEN
+  minSellPrice: 5
   itemsForSale:
     FoodTinMRETrash: 0
     FoodTinPeachesTrash: 0
@@ -602,6 +605,7 @@
 
 - type: shopPreset
   id: OKSOPClothingShopPresetEN
+  minSellPrice: 5
   itemsForSale:
     FoodTinMRETrash: 0
     FoodTinPeachesTrash: 0

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/neutrals.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/neutrals.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NeutralsShopPresetZoneEN # Sidorovich Prices
+  minSellPrice: 5
   itemsForSale:
     # Exclusive -
     DismemberedMarkingEars: 375

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/renegades.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/renegades.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: RenegadesShopPresetEN # Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Exclusive -
     DismemberedMarkingEars: 600

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: STNPCBarmanPresetEN # 1x Standard - Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Exclusive -
     DismemberedMarkingEars: 575

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/BotanikMaks.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/BotanikMaks.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: STFoodBotanicPreset
+  minSellPrice: 5
   itemsForSale:
     FoodSTTomato: 30
     FoodSTPotato: 25

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/NikitaAlkash.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/NikitaAlkash.yml
@@ -1,5 +1,6 @@
 ﻿- type: shopPreset
   id: NpcNikitaAlkashEN
+  minSellPrice: 5
   itemsForSale:
     DrinkBottleVodka: 5
     DrinkWaterBottleFull: 5

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/RadioPlayer.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/RadioPlayer.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcRadioPlayerEN #Will fix this dude later.... Too lazy - Texas Peach
+  minSellPrice: 5
   itemsForSale:
     CasseteOneRadio: 340
     CasseteTwoRadio: 340

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sci_PB.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sci_PB.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcSciPBEN # 1.25x - Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Exclusive
     DismemberedMarkingEars: 725 # realistically researchers would want this item

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sidorovich.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sidorovich.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcSidorEN # 0.75x Barman - Pending Economy Change
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 405

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/VadikNarik.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/VadikNarik.yml
@@ -1,5 +1,6 @@
 ﻿- type: shopPreset
   id: NpcVadikNarikEN
+  minSellPrice: 5
   itemsForSale:
     CannabisSeedsStalker: 1
     Blunt: 1

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/fishing.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/fishing.yml
@@ -1,6 +1,7 @@
 # im not committed to these numbers in any way
 - type: shopPreset
   id: STFishShopPreset
+  minSellPrice: 5
   itemsForSale:
     # normal fish
     STFishBitterling: 20

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/ErjanAlimov.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/ErjanAlimov.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcErjanAlimovEN
+  minSellPrice: 5
   itemsForSale:
     STJewelrySilver: 400
     STJewelryGold: 600

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/JuryIzvorotin.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/JuryIzvorotin.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: NpcJuryIzvorotinEN
+  minSellPrice: 5
   itemsForSale:
     STJewelrySilver: 400
     STJewelryGold: 600

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/kesha.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/kesha.yml
@@ -1,5 +1,6 @@
 - type: shopPreset
   id: KekeshaShopPresetEN # i miss my boy
+  minSellPrice: 5
   itemsForSale:
     # Thermal group - 1
     ZoneArtifactFireball: 400


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Made `MinSellPrice` opt-in (default 0) instead of opt-out (default 5) to fix non-rouble shops hiding low-value items.

**Problem:** Commit `48aa337c1e` added a `MinSellPrice` field on `ShopPresetPrototype` with a default of 5 to hide junk from the sell tab. This default applied to **all** shops regardless of currency, which broke non-rouble shops:
- **MilitaryPremiumShopPresetEN** (PremiumSupplyTalons) — dogtags priced 1-2 were hidden
- **STMeatShopPreset** (Hryvnias) — meat items priced 1-3 were hidden

**Fix:** Changed the default to 0 and explicitly set `minSellPrice: 5` on rouble shop presets that need the filter. Fully data-driven, no hardcoded currency checks.

### C# changes

| File | Change |
|------|--------|
| `Content.Shared/_Stalker/Shop/Prototypes/ShopPresetPrototype.cs` | `MinSellPrice` default 5 → 0 |
| `Content.Server/_Stalker/Shop/ShopSystem.cs` | `GetListingData` parameter default 5 → 0 |

### YAML — shops with `minSellPrice: 5` added

| Shop Preset ID | File | Currency |
|---|---|---|
| STNPCBarmanPresetEN | NPCShops/Barman.yml | Roubles |
| NpcSidorEN | NPCShops/Sidorovich.yml | Roubles |
| NpcSciPBEN | NPCShops/Sci_PB.yml | Roubles |
| NpcRadioPlayerEN | NPCShops/RadioPlayer.yml | Roubles |
| NpcVadikNarikEN | NPCShops/VadikNarik.yml | Roubles |
| STFoodBotanicPreset | NPCShops/BotanikMaks.yml | Roubles |
| NpcNikitaAlkashEN | NPCShops/NikitaAlkash.yml | Roubles |
| STFishShopPreset | NPCShops/fishing.yml | Roubles |
| KekeshaShopPresetEN | PawnShops/PawnShops/kesha.yml | Roubles |
| NpcErjanAlimovEN | PawnShops/PawnShops/ErjanAlimov.yml | Roubles |
| NpcJuryIzvorotinEN | PawnShops/PawnShops/JuryIzvorotin.yml | Roubles |
| FreedomShopPresetEN | FactionTorgomats/freedom.yml | Roubles |
| BandsShopPresetEN | FactionTorgomats/bandits.yml | Roubles |
| ClearSkyShopPresetEN | FactionTorgomats/clearsky.yml | Roubles |
| DolgShopPresetEN | FactionTorgomats/dolg.yml | Roubles |
| MercShopPresetEN | FactionTorgomats/merc.yml | Roubles |
| RenegadesShopPresetEN | FactionTorgomats/renegades.yml | Roubles |
| NeutralsShopPresetZoneEN | FactionTorgomats/neutrals.yml | Roubles |
| NpcResearchInstituteEN | FactionTorgomats/ecologist.yml | Roubles |
| JournalistShopPreset | FactionTorgomats/journalist.yml | Roubles |
| VoenstalShopPresetEN | FactionTorgomats/militaries.yml | Roubles |
| OKSOPShopPresetEN | FactionTorgomats/militaries.yml | Roubles |
| OKSOPOfficerShopPresetEN | FactionTorgomats/militaries.yml | Roubles |
| OKSOPClothingShopPresetEN | FactionTorgomats/militaries.yml | Roubles |
| SantaPreset | Entities/Objects/Decoration/Seasonal/Vendor.yml | Roubles |

### NOT modified (non-rouble — now correctly default to 0)

| Shop Preset ID | File | Currency |
|---|---|---|
| MilitaryPremiumShopPresetEN | FactionTorgomats/militaries.yml | PremiumSupplyTalons |
| STMeatShopPreset | NPCShops/meatman.yml | Hryvnias |

## Changelog
author: @teecoding 

- fix: Non-rouble shops (military premium, meatman) no longer hide low-priced items from the sell tab

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
