### PR TITLE
fix: prevent PDA E-key from toggling flashlight

### DIFF
--- a/Resources/Prototypes/_Stalker/pda.yml
+++ b/Resources/Prototypes/_Stalker/pda.yml
@@ -109,6 +109,7 @@
     - Flashlight
   - type: HandheldLight
     addPrefix: false
+    toggleOnInteract: false # stalker-14-en: prevent E from toggling flashlight, only open PDA UI
     blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Set `toggleOnInteract: false` on the PDA's `HandheldLight` component so pressing E only opens the PDA UI instead of also toggling the flashlight.

## Changelog

author: @teecoding

- fix: PDA flashlight no longer toggles when pressing E to open the PDA

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
