### PR TITLE
feat: disable late-join station announcement

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -9,6 +9,7 @@ using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
 using Content.Shared.CCVar;
+using Content.Shared._Stalker_EN.CCVar;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;
@@ -256,7 +257,9 @@ namespace Content.Server.GameTicking
 
             DoSpawn(player, character, station, jobId, silent, out var mob, out var jobPrototype, out var jobName);
 
-            if (lateJoin && !silent)
+            // stalker-changes-start
+            if (lateJoin && !silent && !_cfg.GetCVar(STCCVars.DisableLateJoinAnnouncement))
+            // stalker-changes-end
             {
                 if (jobPrototype.JoinNotifyCrew)
                 {

--- a/Content.Shared/_Stalker_EN/CCVar/STCCVars.LateJoin.cs
+++ b/Content.Shared/_Stalker_EN/CCVar/STCCVars.LateJoin.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Stalker_EN.CCVar;
+
+// CVars for late-join behavior
+
+public sealed partial class STCCVars
+{
+    /// <summary>
+    ///     If true, disables the station announcement when a player late-joins.
+    /// </summary>
+    public static readonly CVarDef<bool> DisableLateJoinAnnouncement =
+        CVarDef.Create("stalkeren.latejoin.disable_announcement", true, CVar.SERVERONLY);
+}


### PR DESCRIPTION
## What I changed

Disabled the station-wide late-join arrival announcement (e.g. "Character Name (Job) has arrived at the station!") via a new server CVar `stalkeren.latejoin.disable_announcement` (defaults to `true`).

The announcement can be re-enabled at runtime with `cvar stalkeren.latejoin.disable_announcement false` in the server console.

## Changelog

author: @teecoding
- remove: Late-join arrival announcements no longer broadcast to the station

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
