### PR TITLE
fix: prevent entity leak and stale arena grids on stash reconnect

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -504,6 +504,7 @@ namespace Content.Server.Ghost
             {
                 if (adminObserve != true)
                 {
+                    QueueDel(ghost); // clean up orphaned MobObserver to prevent entity leak
                     if (session != null)
                         _gameTicker.Respawn(session);
                     return null;

--- a/Content.Server/_Stalker/Teleports/StalkerPortalSystem.cs
+++ b/Content.Server/_Stalker/Teleports/StalkerPortalSystem.cs
@@ -146,7 +146,7 @@ public sealed class StalkerPortalSystem : SharedTeleportSystem
 
             while (enumerator.MoveNext(out var ent))
             {
-                if (TryComp<MindContainerComponent>(ent, out var mind) && !TryComp<GhostComponent>(ent, out var ghost) && !TryComp<DatasetVocalizerComponent>(ent, out var ad))
+                if (TryComp<MindContainerComponent>(ent, out var mind) && mind.HasMind && !TryComp<GhostComponent>(ent, out var ghost) && !TryComp<DatasetVocalizerComponent>(ent, out var ad))
                 {
                     hasMind = true;
                     break;


### PR DESCRIPTION
## What I changed

Fixed a bug where players who suffocated and despawned inside their stash would have their mind placed into an orphaned observer entity on reconnect.

Two issues were addressed:

1. **MobObserver entity leak in `SpawnGhost`** - When a disconnected player's body is deleted, `SpawnGhost` spawns a `MobObserver` entity, finds it has no `GhostComponent` (Stalker's observer prototype doesn't include one), and returns `null` without deleting the spawned entity. This leaked an orphaned observer that could capture the player's mind on reconnect. Added `QueueDel(ghost)` to clean it up.

2. **Stale arena grid cleanup in `OnClearArenaGrids`** - The arena grid cleanup checked for `MindContainerComponent` to decide whether to keep a stash grid alive, but didn't verify `mind.HasMind`. Dead bodies with empty mind containers (disconnected player + wiped mind) still had the component present, preventing their arena grids from ever being garbage collected. Added `mind.HasMind` to the condition.

## Changelog

author: @teecoding
- fix: Fixed a bug where reconnecting after dying in your stash could put you into an observer object

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
