### PR TITLE
feat: add thief anomaly throw-item effect

### DIFF
--- a/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectThrowItemSystem.cs
+++ b/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectThrowItemSystem.cs
@@ -1,0 +1,115 @@
+using Content.Shared._Stalker.ZoneAnomaly.Components;
+using Content.Shared._Stalker_EN.ZoneAnomaly.Effects.Components;
+using Content.Shared.Actions.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Organ;
+using Content.Shared.Body.Part;
+using Content.Shared.CartridgeLoader;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Implants.Components;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Item;
+using Content.Shared.Mind.Components;
+using Content.Shared.StatusEffectNew.Components;
+using Content.Shared.Throwing;
+using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
+using Robust.Shared.Random;
+
+namespace Content.Server._Stalker_EN.ZoneAnomaly.Effects.Systems;
+
+/// <summary>
+/// Throws items instead of deleting them, giving players a chance to recover their belongings.
+/// </summary>
+public sealed class ZoneAnomalyEffectThrowItemSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ZoneAnomalyEffectThrowItemComponent, ZoneAnomalyActivateEvent>(OnActivate);
+    }
+
+    private void OnActivate(Entity<ZoneAnomalyEffectThrowItemComponent> effect, ref ZoneAnomalyActivateEvent args)
+    {
+        foreach (var trigger in args.Triggers)
+        {
+            if (!HasComp<ContainerManagerComponent>(trigger))
+                continue;
+
+            var items = GetRecursiveContainerElements(trigger);
+            items.Remove(trigger);
+
+            if (items.Count == 0)
+                continue;
+
+            for (var i = 0; i < effect.Comp.Count; i++)
+            {
+                if (items.Count == 0)
+                    break;
+
+                var item = _random.Pick(items);
+                items.Remove(item);
+
+                _container.TryRemoveFromContainer(item, force: true);
+                _transform.DropNextTo(item, trigger);
+
+                var angle = _random.NextAngle();
+                var direction = angle.ToVec();
+
+                _throwing.TryThrow(item, direction * effect.Comp.Distance, effect.Comp.Force);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Filters combine upstream anomaly and repository systems to avoid stealing non-removable internals.
+    /// </summary>
+    private List<EntityUid> GetRecursiveContainerElements(
+        EntityUid uid,
+        ContainerManagerComponent? managerComponent = null)
+    {
+        var result = new List<EntityUid>();
+
+        if (!Resolve(uid, ref managerComponent))
+            return result;
+
+        foreach (var container in managerComponent.Containers)
+        {
+            if (container.Key == "toggleable-clothing")
+                continue;
+
+            foreach (var element in container.Value.ContainedEntities)
+            {
+                if (HasComp<OrganComponent>(element) ||
+                    HasComp<InstantActionComponent>(element) ||
+                    HasComp<WorldTargetActionComponent>(element) ||
+                    HasComp<EntityTargetActionComponent>(element) ||
+                    HasComp<SubdermalImplantComponent>(element) ||
+                    HasComp<BodyPartComponent>(element) ||
+                    HasComp<CartridgeComponent>(element) ||
+                    HasComp<VirtualItemComponent>(element) ||
+                    HasComp<MindContainerComponent>(element) ||
+                    HasComp<StatusEffectComponent>(element) ||
+                    HasComp<UnremoveableComponent>(element) ||
+                    HasComp<SelfUnremovableClothingComponent>(element) ||
+                    HasComp<BloodstreamComponent>(element) ||
+                    !HasComp<ItemComponent>(element))
+                    continue;
+
+                if (TryComp<ContainerManagerComponent>(element, out var manager))
+                    result.AddRange(GetRecursiveContainerElements(element, manager));
+
+                result.Add(element);
+            }
+        }
+
+        return result;
+    }
+}

--- a/Content.Shared/_Stalker_EN/ZoneAnomaly/Effects/Components/ZoneAnomalyEffectThrowItemComponent.cs
+++ b/Content.Shared/_Stalker_EN/ZoneAnomaly/Effects/Components/ZoneAnomalyEffectThrowItemComponent.cs
@@ -1,0 +1,27 @@
+namespace Content.Shared._Stalker_EN.ZoneAnomaly.Effects.Components;
+
+/// <summary>
+/// Steals items from a triggered entity's containers and throws them in random directions.
+/// Replaces the upstream remove-item effect to give players a chance to recover their belongings.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ZoneAnomalyEffectThrowItemComponent : Component
+{
+    /// <summary>
+    /// Number of items to steal per activation, per trigger entity.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int Count = 1;
+
+    /// <summary>
+    /// Direction vector multiplier controlling how far items are thrown.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Distance = 5f;
+
+    /// <summary>
+    /// Throw speed/force applied to stolen items.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Force = 10f;
+}

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/spatial.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/spatial.yml
@@ -13,7 +13,7 @@
     whitelist:
       tags:
         - STBolt
-  - type: ZoneAnomalyEffectRemoveItem
+  - type: ZoneAnomalyEffectThrowItem # stalker-changes: throw items instead of deleting them
     count: 1
   - type: ZoneAnomaly
     detectedLevel: 4

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Anomalies/spatial.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Anomalies/spatial.yml
@@ -1,0 +1,29 @@
+- type: entity
+  parent: ZoneAnomalyBarabashka
+  id: ZoneAnomalyThiefWeak
+  suffix: Stalker, Thief Weak, Anomaly
+  components:
+  - type: ZoneAnomalyEffectThrowItem
+    count: 1
+    distance: 2
+    force: 5
+  - type: ZoneAnomaly
+    detectedLevel: 4
+    preparingDelay: 0
+    activationDelay: 1
+    chargeTime: 6
+
+- type: entity
+  parent: ZoneAnomalyBarabashka
+  id: ZoneAnomalyThiefStrong
+  suffix: Stalker, Thief Strong, Anomaly
+  components:
+  - type: ZoneAnomalyEffectThrowItem
+    count: 2
+    distance: 8
+    force: 15
+  - type: ZoneAnomaly
+    detectedLevel: 4
+    preparingDelay: 0
+    activationDelay: 1
+    chargeTime: 3

--- a/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/ZoneAnomaly/spatial.yml
+++ b/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/ZoneAnomaly/spatial.yml
@@ -1,0 +1,229 @@
+# Thief Weak
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance1
+  name: thief weak anomaly spawner (1% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 1
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 0.01
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance5
+  name: thief weak anomaly spawner (5% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 5
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 0.05
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance10
+  name: thief weak anomaly spawner (10% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 10
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 0.1
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance25
+  name: thief weak anomaly spawner (25% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 25
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 0.25
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance50
+  name: thief weak anomaly spawner (50% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 50
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefWeakChance100
+  name: thief weak anomaly spawner (100% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 100
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefWeak
+    chance: 1.0
+    offset: 0.0
+
+# Thief Strong
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance1
+  name: thief strong anomaly spawner (1% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 1
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 0.01
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance5
+  name: thief strong anomaly spawner (5% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 5
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 0.05
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance10
+  name: thief strong anomaly spawner (10% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 10
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 0.1
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance25
+  name: thief strong anomaly spawner (25% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 25
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 0.25
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance50
+  name: thief strong anomaly spawner (50% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 50
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 0.5
+    offset: 0.0
+
+- type: entity
+  id: SpawnerZoneAnomalyThiefStrongChance100
+  name: thief strong anomaly spawner (100% chance)
+  suffix: Stalker
+  parent: FlexibleMarker
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: _Stalker/Objects/Anomalies/barabashka.rsi
+        state: active
+      - sprite: _Stalker/Markers/numbers.rsi
+        state: 100
+  - type: RandomSpawner
+    prototypes:
+      - ZoneAnomalyThiefStrong
+    chance: 1.0
+    offset: 0.0


### PR DESCRIPTION
## What I changed

Thief anomaly now throws stolen items instead of deleting them. Players can recover their gear after being hit. Adds weak and strong variants with different throw distance and force. Improved item filters to prevent stealing organs, implants, virtual items, unremovable clothing, and other internals.

## Changelog

author: @teecoding

- tweak: Thief anomaly now throws your items instead of destroying them
- add: Weak and strong thief anomaly variants

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
