### PR TITLE
fix: prevent stash portal crash on non-existent prototypes

### DIFF
--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -426,7 +426,10 @@ public sealed class StalkerRepositorySystem : EntitySystem
             return new RepositoryItemInfo();
 
         // Conversion for database type
-        var newSStorageData = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item)[0];
+        var convertedList = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item);
+        if (convertedList.Count == 0)
+            return new RepositoryItemInfo();
+        var newSStorageData = convertedList[0];
         // Identifier for items that had to be unique, items with the same identifier can be stacked.
         var newIdentifier = "";
 
@@ -497,7 +500,10 @@ public sealed class StalkerRepositorySystem : EntitySystem
         foreach (var element in items)
         {
             // generates stalker storage data
-            var ident = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item)[0];
+            var convertedList = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item);
+            if (convertedList.Count == 0)
+                continue;
+            var ident = convertedList[0];
             var identifier = string.Empty;
 
             // gets identifier to determine duplicates
@@ -1039,7 +1045,10 @@ public sealed class StalkerRepositorySystem : EntitySystem
     /// <returns>Identifier in string</returns>
     private string GenerateIdentifier(EntityUid item)
     {
-        var newSStorageData = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item)[0];
+        var convertedList = _stalkerStorageSystem.ConvertToIItemStalkerStorage(item);
+        if (convertedList.Count == 0)
+            return string.Empty;
+        var newSStorageData = convertedList[0];
         if (newSStorageData is IItemStalkerStorage iss)
         {
             return iss.Identifier();

--- a/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
+++ b/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
@@ -338,10 +338,14 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
             if (item is not IItemStalkerStorage storageItem)
                 continue;
 
-            storageItem.PrototypeName = MapPrototype(storageItem.PrototypeName);
+            var mapped = MapPrototype(storageItem.PrototypeName);
+            if (mapped == null)
+                continue;
+
+            storageItem.PrototypeName = mapped.Value;
 
             if (item is AmmoContainerStalker ammoContainer)
-                ammoContainer.EntProtoIds = MapPrototype(ammoContainer.EntProtoIds);
+                ammoContainer.EntProtoIds = MapPrototypeList(ammoContainer.EntProtoIds);
 
             deserializedFromJson.Add(storageItem);
         }
@@ -353,22 +357,32 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
     }
 
     /// <summary>
-    /// Maps a list of prototype IDs through the prototype mapping table.
+    /// Maps a list of prototype IDs through the prototype mapping table, filtering out non-existent prototypes.
     /// Used to handle prototype ID changes between game versions.
     /// </summary>
-    private List<string> MapPrototype(in List<string> protoIds)
+    private List<string> MapPrototypeList(in List<string> protoIds)
     {
-        return protoIds.Select(id => (string)MapPrototype((EntProtoId)id)).ToList();
+        var result = new List<string>(protoIds.Count);
+        foreach (var id in protoIds)
+        {
+            var mapped = MapPrototype((EntProtoId) id);
+            if (mapped != null)
+                result.Add((string) mapped.Value);
+        }
+        return result;
     }
 
-    private EntProtoId MapPrototype(EntProtoId protoId)
+    private EntProtoId? MapPrototype(EntProtoId protoId)
     {
         var prototype = protoId;
         if (_mapping.TryGetValue(prototype, out var newPrototype))
             prototype = newPrototype;
 
         if (!_prototype.HasIndex(prototype))
-            Log.Error($"A non-existent prototype entity in the stash {prototype}");
+        {
+            Log.Error($"A non-existent prototype entity in the stash {prototype}, skipping");
+            return null;
+        }
 
         return prototype;
     }


### PR DESCRIPTION
## What I changed

Fixed stash portal teleportation crash caused by non-existent prototypes in player stash data. When a player's stash contained items referencing deleted prototypes, the `OnCollide` handler would crash with `ArgumentOutOfRangeException` before `TeleportEntity` was called, resulting in the stash grid being created but the player never teleporting in.

## Changelog

author: @teecoding

- fix: Fixed stash portals not teleporting players in when their stash contained items from removed prototypes

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
