### PR TITLE
fix: reset geiger counter to 0 when leaving irradiated area

### DIFF
--- a/Content.Server/Radiation/Systems/GeigerSystem.cs
+++ b/Content.Server/Radiation/Systems/GeigerSystem.cs
@@ -82,6 +82,8 @@ public sealed class GeigerSystem : SharedGeigerSystem
         {
             if (receiver?.CurrentDamage != null && receiver.CurrentDamage.TryGetValue("Radiation", out var rads)) // stalker-changes
                 SetCurrentRadiation(uid, geiger, rads); // stalker-changes
+            else // stalker-changes
+                SetCurrentRadiation(uid, geiger, 0f); // stalker-changes
         }
     }
 


### PR DESCRIPTION
## What I changed

Geiger counters now properly reset to 0 when you leave an irradiated area. Previously, the Stalker multi-damage-type radiation change introduced a bug where the dictionary lookup for "Radiation" would silently skip the update when no radiation sources were reaching the receiver, leaving the geiger stuck at its last reading.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/414

## Changelog

author: @teecoding 

- fix: Geiger counters no longer stay stuck at the last radiation reading after leaving an irradiated area

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
