### PR TITLE
fix: prevent ExamineEntity from blocking weapon fire when Shift is held in combat mode

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
+using Content.Shared.CombatMode;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
@@ -120,6 +121,10 @@ namespace Content.Client.Examine
             {
                 return false;
             }
+
+            // stalker-changes: Don't consume examine input in combat mode so weapons can fire
+            if (TryComp<CombatModeComponent>(player, out var combat) && combat.IsInCombatMode)
+                return false;
 
             DoExamine(entity);
             return true;

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -207,6 +207,7 @@ binds:
   key: MouseLeft
   canFocus: true
   mod1: Shift
+  allowSubCombs: true # stalker-changes: let Use fire alongside ExamineEntity so weapons work with Shift held
 - function: ActivateItemInWorld
   type: State
   key: E


### PR DESCRIPTION
## What I changed

Added `allowSubCombs: true` to the ExamineEntity keybind and a combat mode check in `HandleExamine` so that Shift+Left Click no longer opens the examine tooltip when in combat mode. This lets players who use Shift as their sprint key shoot while sprinting.

## Changelog

author: @teecoding 

- fix: Shift+Left Click no longer blocks shooting in combat mode

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
