### PR TITLE
fix: remove inverted Box2i grid coordinates from belt storage prototypes

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/RPC.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/RPC.yml
@@ -126,9 +126,7 @@
       maxItemSize: Large
       grid:
         - 2,0,7,3
-        - 0,4,0,2
-        - 1,0,0,2
-        - 0,0,0,0
+        - 0,0,1,0
     - type: Sprite
       sprite: _Stalker/Objects/Clothing/belt/belt_green.rsi
       state: icon
@@ -148,10 +146,8 @@
       maxItemSize: Large
       grid:
         - 4,0,9,3
-        - 0,1,0,1
         - 0,0,1,0
-        - 0,4,0,2
-        - 1,0,0,2
+        - 0,1,0,1
         - 2,2,2,2
     - type: Sprite
       sprite: _Stalker/Objects/Clothing/belt/belt_officer.rsi
@@ -213,10 +209,8 @@
       maxItemSize: Large
       grid:
         - 4,0,9,3
-        - 0,1,0,1
         - 0,0,1,0
-        - 0,4,0,2
-        - 1,0,0,2
+        - 0,1,0,1
         - 2,2,2,2
     - type: Sprite
       sprite: _Stalker/Objects/Clothing/belt/belt_berill.rsi
@@ -420,10 +414,8 @@
       maxItemSize: Large
       grid:
         - 4,0,9,3
-        - 0,1,0,1
         - 0,0,1,0
-        - 0,4,0,2
-        - 1,0,0,2
+        - 0,1,0,1
         - 2,2,2,2
     - type: Sprite
       sprite: _Stalker/Objects/Clothing/belt/belt_deserter_holster.rsi


### PR DESCRIPTION
## What I changed

Fixed broken storage grid definitions on 4 belt items that used inverted `Box2i` coordinates (`0,4,0,2` and `1,0,0,2`), causing visual glitches in the storage UI. Same class of bug as the cape storage fix in 7d1d2030ef.

Affected belts:
- ClothingBeltGreenWebbingStalker (PZS Waist Bag)
- ClothingBeltWebbingOfficerStalker (PZS Officer)
- ClothingBeltWebbingBerill (Berill-5M)
- ClothingBeltWebbingDeserter (Deserter)

## Changelog

author: @teecoding

- fix: Fixed storage grid display glitches on PZS Waist Bag, PZS Officer, Berill-5M and Deserter belts

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
