### PR TITLE
fix: prevent anomaly detector toggle from blocking Svarog UI interaction

### DIFF
--- a/Content.Shared/_Stalker/ZoneAnomaly/Components/ZoneAnomalyDetectorComponent.cs
+++ b/Content.Shared/_Stalker/ZoneAnomaly/Components/ZoneAnomalyDetectorComponent.cs
@@ -27,6 +27,14 @@ public sealed partial class ZoneAnomalyDetectorComponent : Component
 
     [DataField]
     public SoundSpecifier BeepSound = new SoundPathSpecifier("/Audio/Items/locator_beep.ogg");
+
+    /// <summary>
+    /// Whether the detector can be toggled on/off via standard interactions (use in hand, etc).
+    /// Set to false when the entity also has an ActivatableUI to prevent the toggle from
+    /// consuming the interaction event before the UI system can open.
+    /// </summary>
+    [DataField]
+    public bool ToggleOnInteract = true; // stalker-changes
 }
 
 [RegisterComponent]

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Devices/svarog.yml
@@ -31,5 +31,6 @@
     maxBeepInterval: 1
     minBeepInterval: 0.01
     beepSound: /Audio/_Stalker/Items/Detectors/Anomaly/da_beep3.ogg
+    toggleOnInteract: false
   - type: STWeight
     self: 1.8


### PR DESCRIPTION
## What I changed

Svarog's UseInHand event was being consumed by the anomaly detector toggle, preventing the radar UI from opening on left-click and Y key. Added a `toggleOnInteract` field to `ZoneAnomalyDetectorComponent` (same pattern as the PDA flashlight fix) so the detector toggle can be disabled on entities that also have an ActivatableUI. Players can still toggle the beeping via the right-click verb menu.

Closes #430

## Changelog

author: @teecoding

- fix: Fixed Svarog radar UI not opening on left-click or Y key

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
