### PR TITLE
feat: add gacha-style random plushie spawner for mappers

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/Mapping/Plushies.yml
+++ b/Resources/Prototypes/_Stalker_EN/SpawnersNTriggers/Mapping/Plushies.yml
@@ -1,0 +1,92 @@
+# Gacha-style random plushie spawner for mappers.
+# Plushies are weighted by rarity: common (3x), uncommon (2x), rare (1x), ultra-rare (rarePrototypes).
+- type: entity
+  name: Random Plushie Spawner
+  id: STPlushieSpawner
+  suffix: ST, Gacha
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Objects/Fun/Plushies/bee.rsi
+          state: icon
+    - type: RandomSpawner
+      rarePrototypes:
+        - PlushieGhost
+        - PlushieRGBee
+        - PlushieRainbowCarp
+        - PlushieRainbowLizard
+        - PlushieThrongler
+        - PlushieMagicarp
+        - PlushieHolocarp
+      rareChance: 0.05
+      prototypes:
+        # Common (3x weight) - everyday finds
+        - STPlushieFeltCat1
+        - STPlushieFeltCat1
+        - STPlushieFeltCat1
+        - STPlushieFeltCat2
+        - STPlushieFeltCat2
+        - STPlushieFeltCat2
+        - STPlushieFeltCat3
+        - STPlushieFeltCat3
+        - STPlushieFeltCat3
+        - ToyMouse
+        - ToyMouse
+        - ToyMouse
+        - PlushieSlime
+        - PlushieSlime
+        - PlushieSlime
+        - PlushieSnake
+        - PlushieSnake
+        - PlushieSnake
+        # Uncommon (2x weight) - nice finds
+        - STPlushieFeltFlesh
+        - STPlushieFeltFlesh
+        - STPlushieBunny
+        - STPlushieBunny
+        - PlushieBee
+        - PlushieBee
+        - PlushieLizard
+        - PlushieLizard
+        - PlushieCarp
+        - PlushieCarp
+        - PlushieAtmosian
+        - PlushieAtmosian
+        - PlushieNuke
+        - PlushieNuke
+        - PlushieVox
+        - PlushieVox
+        - PlushieDiona
+        - PlushieDiona
+        - PlushieArachind
+        - PlushieArachind
+        - PlushieHampter
+        - PlushieHampter
+        - PlushieSharkBlue
+        - PlushieSharkBlue
+        - PlushieSharkPink
+        - PlushieSharkPink
+        - PlushieSharkGrey
+        - PlushieSharkGrey
+        - PlushieMoth
+        - PlushieMoth
+        - PlushieVulp
+        - PlushieVulp
+        - PlushiePenguin
+        - PlushiePenguin
+        - PlushieHuman
+        - PlushieHuman
+        - PlushieExperiment
+        - PlushieExperiment
+        # Rare (1x weight) - lucky finds
+        - PlushieOldStalker
+        - PlushieSpaceLizard
+        - PlushieRouny
+        - PlushieLamp
+        - PlushieNar
+        - PlushieRatvar
+        - PlushieXeno
+      chance: 1.0
+      offset: 0.2


### PR DESCRIPTION
## What I changed
Added a gacha-style random plushie spawner (`STPlushieSpawner`) for mappers. Spawns a random plushie from a weighted pool combining Stalker and SS14 plushies with four rarity tiers: common, uncommon, rare, and ultra-rare.

## Changelog
author: @teecoding

- add: Random plushie spawner with gacha-style rarity tiers for map variety

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
