### PR TITLE
feat: add Russian accent as a selectable character trait

### DIFF
--- a/Resources/Locale/en-US/_Stalker_EN/traits/speech.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/traits/speech.ftl
@@ -1,0 +1,2 @@
+trait-russian-name = Russian accent
+trait-russian-desc = Da, comrade. You speak with a heavy Russian accent.

--- a/Resources/Prototypes/_Stalker_EN/Traits/speech.yml
+++ b/Resources/Prototypes/_Stalker_EN/Traits/speech.yml
@@ -1,0 +1,8 @@
+- type: trait
+  id: RussianAccent
+  name: trait-russian-name
+  description: trait-russian-desc
+  category: SpeechTraits
+  cost: 1
+  components:
+  - type: RussianAccent


### PR DESCRIPTION
## What I changed

Added Russian accent as a selectable character trait in the character customization menu. Players can now pick the Russian accent (1 point, Speech Traits category) without needing to wear an ushanka hat.

## Changelog

author: @teecoding 

- add: Russian accent is now available as a character trait in the customization menu

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
