### PR TITLE
feat: add eject magazine (J) and toggle bolt (L) keybinds for guns

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -76,6 +76,8 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipOuterClothing); // Stalker-Changes-UI
             human.AddFunction(ContentKeyFunctions.Lay); // Stalker-Changes-UI
             human.AddFunction(ContentKeyFunctions.STQuickEquipBolt); // Stalker-Changes-UI
+            human.AddFunction(ContentKeyFunctions.STEjectMagazine); // Stalker-Changes-UI
+            human.AddFunction(ContentKeyFunctions.STToggleBolt); // Stalker-Changes-UI
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
             human.AddFunction(ContentKeyFunctions.SmartEquipPocket1);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -321,6 +321,8 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.SmartEquipOuterClothing);
             AddButton(ContentKeyFunctions.Lay);
             AddButton(ContentKeyFunctions.STQuickEquipBolt);
+            AddButton(ContentKeyFunctions.STEjectMagazine);
+            AddButton(ContentKeyFunctions.STToggleBolt);
             // stalker-changes-end
 
             foreach (var control in _keyControls.Values)

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -37,6 +37,8 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipOuterClothing = "SmartEquipOuterClothing"; // Stalker-Changes-UI
         public static readonly BoundKeyFunction Lay = "Lay"; // Stalker-Changes-UI
         public static readonly BoundKeyFunction STQuickEquipBolt = "STQuickEquipBolt"; // Stalker-Changes-UI
+        public static readonly BoundKeyFunction STEjectMagazine = "STEjectMagazine"; // Stalker-Changes-UI
+        public static readonly BoundKeyFunction STToggleBolt = "STToggleBolt"; // Stalker-Changes-UI
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
         public static readonly BoundKeyFunction SmartEquipPocket1 = "SmartEquipPocket1";
         public static readonly BoundKeyFunction SmartEquipPocket2 = "SmartEquipPocket2";

--- a/Content.Shared/_Stalker_EN/MagazineEject/STEjectMagazineSystem.cs
+++ b/Content.Shared/_Stalker_EN/MagazineEject/STEjectMagazineSystem.cs
@@ -1,0 +1,57 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Shared._Stalker_EN.MagazineEject;
+
+/// <summary>
+/// Handles the R key magazine eject keybind. Ejects the magazine from the gun
+/// currently held in the player's active hand.
+/// </summary>
+public sealed class STEjectMagazineSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
+    private const string MagazineSlot = "gun_magazine";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.STEjectMagazine,
+                InputCmdHandler.FromDelegate(HandleEjectMagazine, handle: false, outsidePrediction: false))
+            .Register<STEjectMagazineSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        CommandBinds.Unregister<STEjectMagazineSystem>();
+    }
+
+    private void HandleEjectMagazine(ICommonSession? session)
+    {
+        if (session?.AttachedEntity is not { Valid: true } user || !Exists(user))
+            return;
+
+        if (!_hands.TryGetActiveItem(user, out var held))
+            return;
+
+        if (!_actionBlocker.CanInteract(user, null))
+            return;
+
+        if (!_itemSlots.TryGetSlot(held.Value, MagazineSlot, out var slot))
+            return;
+
+        if (!slot.HasItem)
+            return;
+
+        _itemSlots.TryEjectToHands(held.Value, slot, user, excludeUserAudio: true);
+    }
+}

--- a/Content.Shared/_Stalker_EN/ToggleBolt/STToggleBoltSystem.cs
+++ b/Content.Shared/_Stalker_EN/ToggleBolt/STToggleBoltSystem.cs
@@ -1,0 +1,56 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Input;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Shared._Stalker_EN.ToggleBolt;
+
+/// <summary>
+/// Handles the T key toggle bolt keybind. Toggles the bolt open/closed on the gun
+/// currently held in the player's active hand.
+/// </summary>
+public sealed class STToggleBoltSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.STToggleBolt,
+                InputCmdHandler.FromDelegate(HandleToggleBolt, handle: false, outsidePrediction: false))
+            .Register<STToggleBoltSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        CommandBinds.Unregister<STToggleBoltSystem>();
+    }
+
+    private void HandleToggleBolt(ICommonSession? session)
+    {
+        if (session?.AttachedEntity is not { Valid: true } user || !Exists(user))
+            return;
+
+        if (!_hands.TryGetActiveItem(user, out var held))
+            return;
+
+        if (!_actionBlocker.CanInteract(user, null))
+            return;
+
+        if (!TryComp<ChamberMagazineAmmoProviderComponent>(held.Value, out var chamber))
+            return;
+
+        if (chamber.BoltClosed == null)
+            return;
+
+        _gun.ToggleBolt(held.Value, chamber, user);
+    }
+}

--- a/Resources/Locale/en-US/_Stalker_EN/ui-options.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/ui-options.ftl
@@ -1,0 +1,2 @@
+ui-options-function-st-eject-magazine = Eject magazine
+ui-options-function-st-toggle-bolt = Toggle bolt

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -660,4 +660,10 @@ binds:
 - function: STQuickEquipBolt
   type: State
   key: N
+- function: STEjectMagazine
+  type: State
+  key: J
+- function: STToggleBolt
+  type: State
+  key: L
   # stalker-changes-ends


### PR DESCRIPTION
## What I changed

Added dedicated keybinds for gun magazine ejection and bolt toggling, bypassing the verb menu entirely.

- **J** - Eject magazine from gun in active hand
- **L** - Toggle bolt open/close on gun in active hand

Both keybinds appear under the Stalker 14 section in Options and are fully rebindable.

## Changelog

author: @teecoding

- add: Eject magazine keybind (J) and toggle bolt keybind (L) for guns

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
