### PR TITLE
fix: add threshold-based sprite selection to currency stack prototypes

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/dollar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/dollar.yml
@@ -20,6 +20,9 @@
     - cash_100
     - cash_1000
     - cash_5000
+    layerFunction: Threshold
+  - type: StackLayerThreshold
+    thresholds: [20, 100, 1000, 5000]
   - type: Sprite
     sprite: _Stalker/Objects/Economy/dollar.rsi
     state: cash

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/goldcoins.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/goldcoins.yml
@@ -17,6 +17,9 @@
     layerStates:
     - cash
     - cash_5
+    layerFunction: Threshold
+  - type: StackLayerThreshold
+    thresholds: [5]
   - type: Sprite
     sprite: _Stalker/Objects/Economy/coins.rsi
     state: cash

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/rubles.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/Value/rubles.yml
@@ -22,6 +22,9 @@
     - cash_1000
     - cash_2000
     - cash_5000
+    layerFunction: Threshold
+  - type: StackLayerThreshold
+    thresholds: [10, 50, 100, 1000, 2000, 5000]
   - type: Sprite
     sprite: _Stalker/Objects/Economy/rubles.rsi
     state: cash

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Other/fakerubles.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Other/fakerubles.yml
@@ -18,6 +18,9 @@
     - cash
     - cash_20
     - cash_100
+    layerFunction: Threshold
+  - type: StackLayerThreshold
+    thresholds: [20, 100]
   - type: Sprite
     sprite: _Stalker/Objects/Economy/rubles.rsi
     state: cash

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Economy/Currency/hryvnia.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Economy/Currency/hryvnia.yml
@@ -16,6 +16,9 @@
       - cash
       - cash_10
       - cash_100
+      layerFunction: Threshold
+    - type: StackLayerThreshold
+      thresholds: [10, 100]
     - type: Sprite
       sprite: _Stalker_EN/Objects/Economy/hryvnia.rsi
       state: cash


### PR DESCRIPTION
## What I changed

Added `layerFunction: Threshold` and `StackLayerThreshold` component to all currency prototypes (roubles, dollars, hryvnias, gold coins, fake roubles). Without these, the stack sprite selection used `RoundToEqualLevels` which produced incorrect results -- always showing the lowest sprite or wildly wrong denominations depending on timing. Now uses the same threshold-based approach as base SS14's `SpaceCash`.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/427

## Changelog

author: @teecoding

- fix: Currency stacks now display the correct sprite for their amount

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license