### PR TITLE
fix: exclude attached clothing from loadout item count

### DIFF
--- a/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
+++ b/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
@@ -1515,6 +1515,8 @@ public sealed class LoadoutSystem : EntitySystem
                HasComp<Content.Shared.Inventory.VirtualItem.VirtualItemComponent>(item) ||
                HasComp<Content.Shared.Mind.Components.MindContainerComponent>(item) ||
                HasComp<Content.Shared.Chemistry.Components.SolutionComponent>(item) ||
+               // Attached clothing (e.g., hardsuit helmets, hoods) - auto-spawned by ToggleableClothingSystem
+               HasComp<Content.Shared.Clothing.Components.AttachedClothingComponent>(item) ||
                // Unremovable components
                HasComp<Content.Shared.Interaction.Components.UnremoveableComponent>(item) ||
                HasComp<Content.Shared.Clothing.Components.SelfUnremovableClothingComponent>(item);


### PR DESCRIPTION
## What I changed

Toggleable clothing sub-parts (hardsuit helmets, hoods) are no longer counted as separate items when saving a loadout. They are auto-spawned by their parent clothing item and should not be tracked independently.

Closes #449

## Changelog

author: @teecoding

- fix: Loadout no longer counts toggled helmets and hoods as separate items

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
