### PR TITLE
fix: use proper container removal to prevent PVS desync when ashing/gibbing (#441)

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -326,11 +326,17 @@ public partial class SharedBodySystem
         var bodyTransform = Transform(bodyId);
         if (TryComp<InventoryComponent>(bodyId, out var inventory))
         {
+            // stalker-en-changes-start: use proper container removal to fix PVS desync (#441)
+            var bodyCoords = bodyTransform.Coordinates;
             foreach (var item in _inventory.GetHandOrInventoryEntities(bodyId))
             {
-                SharedTransform.DropNextTo(item, (bodyId, bodyTransform));
+                if (Containers.TryGetContainingContainer(item, out var container))
+                    Containers.Remove(item, container, force: true, destination: bodyCoords);
+                else
+                    SharedTransform.DropNextTo(item, (bodyId, bodyTransform));
                 gibs.Add(item);
             }
+            // stalker-en-changes-end
         }
         _audioSystem.PlayPredicted(gibSoundOverride, bodyTransform.Coordinates, null);
         return gibs;


### PR DESCRIPTION
## What I changed

Replaced `TransformSystem.DropNextTo()` with `SharedContainerSystem.Remove(destination:)` when dropping inventory items during ashing (BurnBodyBehavior) and gibbing (GibBody). `DropNextTo` bypasses proper container removal, causing the broadphase system to skip registering dropped items because the `InContainer` flag is still set when the move event fires. This makes items invisible to nearby players until they reconnect.

The fix uses the same container removal pattern as `TryUnequip` in `InventorySystem.Equip.cs`, which clears `InContainer` before repositioning.

- Closes #441 

## Changelog

author: @teecoding

- fix: Items dropped from players who burn to ash or get gibbed are now visible to nearby players without needing to reconnect

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
