### PR TITLE
feat: add soft crit system with prone crawling and forced whisper

### DIFF
--- a/Content.Client/_Stalker_EN/SoftCrit/STSoftCritSystem.cs
+++ b/Content.Client/_Stalker_EN/SoftCrit/STSoftCritSystem.cs
@@ -1,0 +1,9 @@
+namespace Content.Client._Stalker_EN.SoftCrit;
+
+/// <summary>
+/// Client-side stub for the soft crit system.
+/// Reserved for future visual enhancements such as vignette overlays or crawl animations.
+/// </summary>
+public sealed class STSoftCritSystem : EntitySystem
+{
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Players.RateLimiting;
 using Content.Shared.Radio;
 using Content.Shared.Station.Components;
 using Content.Shared.Whitelist;
+using Content.Shared._Stalker_EN.SoftCrit;
 using Robust.Server.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -221,6 +222,15 @@ public new const int VoiceRange = 15; // how far voice goes in world units
                 SendEntityWhisper(source, modMessage, range, channel, nameOverride, hideLog, ignoreActionBlocker);
                 return;
             }
+        }
+
+        // stalker-en-changes: soft crit forces speech to whisper
+        var softCritEv = new STSoftCritSpeechEvent(source);
+        RaiseLocalEvent(source, ref softCritEv);
+        if (softCritEv.Override)
+        {
+            desiredType = InGameICChatType.Whisper;
+            ignoreActionBlocker = true;
         }
 
         // Otherwise, send whatever type.

--- a/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritComponent.cs
+++ b/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritComponent.cs
@@ -1,0 +1,28 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.SoftCrit;
+
+/// <summary>
+/// Runtime component that is dynamically added/removed when an entity is in the soft crit sub-phase
+/// of <see cref="Content.Shared.Mobs.MobState.Critical"/>. Its presence means the entity can crawl
+/// slowly and whisper, but cannot stand, use items, or speak normally.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STSoftCritComponent : Component
+{
+    /// <summary>
+    /// Movement speed multiplier while crawling in soft crit (copied from
+    /// <see cref="STSoftCritEnabledComponent.CrawlSpeedModifier"/> at creation time).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float CrawlSpeedModifier = 0.3f;
+
+    /// <summary>
+    /// Total damage threshold at which soft crit ends and hard crit begins.
+    /// Computed as: critThreshold + (deadThreshold - critThreshold) * softCritFraction.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 HardCritThreshold;
+}

--- a/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritEnabledComponent.cs
+++ b/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritEnabledComponent.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.SoftCrit;
+
+/// <summary>
+/// YAML-configurable marker component that opts an entity into the soft crit system.
+/// When present, entities entering <see cref="Content.Shared.Mobs.MobState.Critical"/> will have
+/// their crit range split into a soft phase (crawling + whispering) and a hard phase (fully incapacitated).
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STSoftCritEnabledComponent : Component
+{
+    /// <summary>
+    /// Fraction of the Critical-to-Dead damage range that counts as "soft crit."
+    /// With default thresholds (Critical=100, Dead=200) and a fraction of 0.5,
+    /// soft crit covers 100-149 damage and hard crit covers 150-199.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SoftCritFraction = 0.5f;
+
+    /// <summary>
+    /// Movement speed multiplier applied during soft crit (0.3 = 30% of normal speed).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float CrawlSpeedModifier = 0.3f;
+}

--- a/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritEvents.cs
+++ b/Content.Shared/_Stalker_EN/SoftCrit/STSoftCritEvents.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._Stalker_EN.SoftCrit;
+
+/// <summary>
+/// Raised on the source entity before the chat type switch in ChatSystem.
+/// If a handler sets <see cref="Override"/> to true, the speech type is forced to whisper
+/// and action blocker checks are bypassed.
+/// </summary>
+[ByRefEvent]
+public record struct STSoftCritSpeechEvent(EntityUid Source)
+{
+    public bool Override = false;
+}

--- a/Content.Shared/_Stalker_EN/SoftCrit/SharedSTSoftCritSystem.cs
+++ b/Content.Shared/_Stalker_EN/SoftCrit/SharedSTSoftCritSystem.cs
@@ -1,0 +1,162 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Stunnable;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Stalker_EN.SoftCrit;
+
+/// <summary>
+/// Splits the <see cref="MobState.Critical"/> damage range into two sub-phases:
+/// <list type="bullet">
+///   <item><b>Soft crit</b> (lower damage): entity is forced prone, can crawl at reduced speed, speech forced to whisper.</item>
+///   <item><b>Hard crit</b> (higher damage): fully incapacitated (current vanilla behavior).</item>
+/// </list>
+/// This system dynamically adds/removes <see cref="STSoftCritComponent"/> based on total damage
+/// relative to a computed hard-crit threshold. When present, the component uncancels movement events
+/// that <see cref="MobStateSystem"/> blocks, and applies a severe speed penalty.
+/// </summary>
+public sealed class SharedSTSoftCritSystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _speedModifier = default!;
+    [Dependency] private readonly MobThresholdSystem _threshold = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<STSoftCritEnabledComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<STSoftCritEnabledComponent, DamageChangedEvent>(OnDamageChanged);
+
+        SubscribeLocalEvent<STSoftCritComponent, ComponentInit>(OnSoftCritInit);
+        SubscribeLocalEvent<STSoftCritComponent, ComponentShutdown>(OnSoftCritShutdown);
+
+        // Must run after MobStateSystem so we can uncancel the movement blocks it applies during crit.
+        SubscribeLocalEvent<STSoftCritComponent, UpdateCanMoveEvent>(OnUpdateCanMove,
+            after: [typeof(MobStateSystem)]);
+        SubscribeLocalEvent<STSoftCritComponent, ChangeDirectionAttemptEvent>(OnChangeDirectionAttempt,
+            after: [typeof(MobStateSystem)]);
+
+        SubscribeLocalEvent<STSoftCritComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshSpeed);
+        SubscribeLocalEvent<STSoftCritComponent, STSoftCritSpeechEvent>(OnSoftCritSpeech);
+    }
+
+    private void OnMobStateChanged(Entity<STSoftCritEnabledComponent> entity, ref MobStateChangedEvent args)
+    {
+        // Server state is authoritative -- don't add/remove components during client state replay.
+        if (_timing.ApplyingState)
+            return;
+
+        if (args.NewMobState == MobState.Critical)
+            TryEnterSoftCrit(entity, entity.Comp);
+        else
+            RemCompDeferred<STSoftCritComponent>(entity);
+    }
+
+    private void OnDamageChanged(EntityUid uid, STSoftCritEnabledComponent enabled, DamageChangedEvent args)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        if (!TryComp<MobStateComponent>(uid, out var mobState) || mobState.CurrentState != MobState.Critical)
+            return;
+
+        if (TryComp<STSoftCritComponent>(uid, out var softCrit))
+        {
+            if (args.Damageable.TotalDamage >= softCrit.HardCritThreshold)
+                RemCompDeferred<STSoftCritComponent>(uid);
+        }
+        else
+        {
+            TryEnterSoftCrit(uid, enabled);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to add <see cref="STSoftCritComponent"/> if the entity's current damage
+    /// falls within the soft crit range.
+    /// </summary>
+    private void TryEnterSoftCrit(EntityUid uid, STSoftCritEnabledComponent enabled)
+    {
+        if (!_threshold.TryGetThresholdForState(uid, MobState.Critical, out var critThreshold))
+            return;
+
+        if (!_threshold.TryGetThresholdForState(uid, MobState.Dead, out var deadThreshold))
+            return;
+
+        var hardCritThreshold = critThreshold.Value + (deadThreshold.Value - critThreshold.Value) * enabled.SoftCritFraction;
+
+        if (!TryComp<DamageableComponent>(uid, out var damageable))
+            return;
+
+        if (damageable.TotalDamage >= hardCritThreshold)
+            return;
+
+        var softCrit = EnsureComp<STSoftCritComponent>(uid);
+        softCrit.CrawlSpeedModifier = enabled.CrawlSpeedModifier;
+        softCrit.HardCritThreshold = hardCritThreshold;
+        Dirty(uid, softCrit);
+    }
+
+    private void OnSoftCritInit(Entity<STSoftCritComponent> entity, ref ComponentInit args)
+    {
+        _blocker.UpdateCanMove(entity);
+        _speedModifier.RefreshMovementSpeedModifiers(entity);
+    }
+
+    private void OnSoftCritShutdown(Entity<STSoftCritComponent> entity, ref ComponentShutdown args)
+    {
+        _blocker.UpdateCanMove(entity);
+        _speedModifier.RefreshMovementSpeedModifiers(entity);
+    }
+
+    private void OnUpdateCanMove(Entity<STSoftCritComponent> entity, ref UpdateCanMoveEvent args)
+    {
+        // ComponentShutdown triggers UpdateCanMove -- without this guard we'd re-enable movement
+        // during teardown, fighting the transition back to hard crit or death.
+        if (entity.Comp.LifeStage > ComponentLifeStage.Running)
+            return;
+
+        // Don't override movement blocks imposed by other systems (stun, buckle, etc.).
+        if (HasComp<StunnedComponent>(entity))
+            return;
+
+        if (TryComp<BuckleComponent>(entity, out var buckle) && buckle.Buckled)
+            return;
+
+        if (HasComp<BlockMovementComponent>(entity))
+            return;
+
+        args.Uncancel();
+    }
+
+    private void OnChangeDirectionAttempt(Entity<STSoftCritComponent> entity, ref ChangeDirectionAttemptEvent args)
+    {
+        // Same LifeStage guard as OnUpdateCanMove -- prevent uncancel during teardown.
+        if (entity.Comp.LifeStage > ComponentLifeStage.Running)
+            return;
+
+        args.Uncancel();
+    }
+
+    private void OnRefreshSpeed(Entity<STSoftCritComponent> entity, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        args.ModifySpeed(entity.Comp.CrawlSpeedModifier);
+    }
+
+    private void OnSoftCritSpeech(Entity<STSoftCritComponent> entity, ref STSoftCritSpeechEvent args)
+    {
+        args.Override = true;
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -117,6 +117,9 @@
       0: Alive
       100: Critical
       200: Dead
+  - type: STSoftCritEnabled # stalker-en-changes
+    softCritFraction: 0.5
+    crawlSpeedModifier: 0.3
   - type: MobStateActions
     actions:
       Critical:


### PR DESCRIPTION
## What I changed

Added a soft crit system that splits the Critical state into two phases:
- **Soft crit** (first half of crit damage range): player is forced prone but can slowly crawl and whisper
- **Hard crit** (second half of crit damage range): fully incapacitated, same as current behavior

Configurable per-prototype via `STSoftCritEnabled` component (`softCritFraction`, `crawlSpeedModifier`).

## Changelog

author: @teecoding

- add: Players in soft crit can now slowly crawl on the ground and whisper to nearby players before going fully unconscious

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
