### PR TITLE
fix: filter observer spawn fallback to station grids to prevent aghost spawning in stashes

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -8,6 +8,7 @@ using Content.Server.Ghost;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
+using Content.Shared.Station.Components; // stalker-en: for StationMemberComponent filter
 using Content.Shared.CCVar;
 using Content.Shared._Stalker_EN.CCVar;
 using Content.Shared.Database;
@@ -459,9 +460,11 @@ namespace Content.Server.GameTicking
 
             var metaQuery = GetEntityQuery<MetaDataComponent>();
 
-            // Fallback to a random grid.
+            // stalker-en-start: filter to station grids to avoid spawning in personal arenas/stashes
+            // Fallback to a random station grid.
             if (_possiblePositions.Count == 0)
             {
+                var stationMemberQuery = GetEntityQuery<StationMemberComponent>();
                 var query = AllEntityQuery<MapGridComponent>();
                 while (query.MoveNext(out var uid, out var grid))
                 {
@@ -470,9 +473,13 @@ namespace Content.Server.GameTicking
                         continue;
                     }
 
+                    if (!stationMemberQuery.HasComponent(uid))
+                        continue;
+
                     _possiblePositions.Add(new EntityCoordinates(uid, Vector2.Zero));
                 }
             }
+            // stalker-en-end
 
             if (_possiblePositions.Count != 0)
             {


### PR DESCRIPTION
## What I changed

Fixed admin ghosts (aghost) spawning inside random personal stashes instead of on the game map. The observer spawn point fallback now only considers station grids, filtering out personal arena grids created by the portal system.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/455

## Changelog

author: @teecoding

- fix: Admin ghosts no longer spawn inside random stashes when joining or reconnecting as observer

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
