### PR TITLE
fix: prevent artifacts from triggering anomalies on spawn

### DIFF
--- a/Content.Shared/_Stalker/ZoneAnomaly/Triggers/ZoneAnomalyTriggerCollideComponent.cs
+++ b/Content.Shared/_Stalker/ZoneAnomaly/Triggers/ZoneAnomalyTriggerCollideComponent.cs
@@ -1,4 +1,6 @@
-﻿using Content.Shared.Whitelist;
+﻿using Content.Shared.Tag;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Stalker.ZoneAnomaly.Triggers;
 
@@ -9,6 +11,10 @@ public abstract partial class ZoneAnomalyTriggerCollideComponent : Component
     /// </summary>
     public readonly EntityWhitelist? BaseBlacklist = new()
     {
+        Tags = new List<ProtoId<TagPrototype>>
+        {
+            "STArtifact",
+        },
         Components = new []
         {
             "Projectile",


### PR DESCRIPTION
## What I changed

Added `STArtifact` tag to the anomaly trigger `BaseBlacklist` so artifacts no longer trigger anomalies when spawning inside them. This was a side effect of adding `HighImpassable` to anomaly fixture layers for the bolt collision fix.  This introduces another side effect which is intentional. Artifacts can no longer trigger anomalies.

## Changelog

author: @teecoding

- fix: Artifacts no longer trigger anomalies when spawning inside them

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
