### PR TITLE
fix: add Russian accent to ushanka hats

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Head/HeadClothing.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Head/HeadClothing.yml
@@ -67,6 +67,7 @@
   - type: Appearance
   - type: AddAccentClothing
     accent: RussianAccent
+  - type: STToggleableAccentClothing # stalker-changes
   - type: Foldable
     canFoldInsideContainer: true
   - type: FoldableClothing

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Head/hats.yml
@@ -86,3 +86,6 @@
     sprite: _Stalker/Objects/Clothing/hats/ushanka.rsi
   - type: Clothing
     sprite: _Stalker/Objects/Clothing/hats/ushanka.rsi
+  - type: AddAccentClothing
+    accent: RussianAccent
+  - type: STToggleableAccentClothing # stalker-changes


### PR DESCRIPTION
## What I changed
Added Russian accent to ushanka hats that were missing it (STClothingHeadUshanka, STClothingHeadHatFoma).

## Changelog
author: @teecoding

- fix: Ushanka hats now properly give a Russian accent when worn

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
