### PR TITLE
fix: prevent CPR self-interaction from blocking buckle and fire-pat

### DIFF
--- a/Content.Server/_Stalker/Medical/CPR/STCPRSystem.cs
+++ b/Content.Server/_Stalker/Medical/CPR/STCPRSystem.cs
@@ -38,13 +38,6 @@ public sealed class STCPRSystem : SharedSTCPRSystem
         var user = args.User;
         var target = uid;
 
-        // Self-CPR: show popup only
-        if (user == target)
-        {
-            _popup.PopupEntity(Loc.GetString("st-cpr-fail-self"), target, user);
-            return;
-        }
-
         // Start popups
         _popup.PopupEntity(
             Loc.GetString("st-cpr-start-performer", ("target", Identity.Entity(target, EntityManager))),
@@ -113,8 +106,7 @@ public sealed class STCPRSystem : SharedSTCPRSystem
         // Success popups
         _popup.PopupEntity(
             Loc.GetString("st-cpr-success-performer",
-                ("target", Identity.Entity(target, EntityManager)),
-                ("seconds", (int) comp.CooldownSeconds)),
+                ("target", Identity.Entity(target, EntityManager))),
             target, user);
         _popup.PopupEntity(
             Loc.GetString("st-cpr-success-others",

--- a/Content.Shared/_Stalker/Medical/CPR/SharedSTCPRSystem.cs
+++ b/Content.Shared/_Stalker/Medical/CPR/SharedSTCPRSystem.cs
@@ -33,11 +33,7 @@ public abstract class SharedSTCPRSystem : EntitySystem
 
         // Can't CPR yourself
         if (user == target)
-        {
-            args.Handled = true;
-            AttemptCPR(uid, comp, args);
             return;
-        }
 
         // Target must have MobState and be critical or dead
         if (!TryComp<MobStateComponent>(target, out var mobState))

--- a/Resources/Locale/en-US/_stalker/medical/cpr.ftl
+++ b/Resources/Locale/en-US/_stalker/medical/cpr.ftl
@@ -1,7 +1,6 @@
 st-cpr-start-performer = You start performing CPR on {$target}.
 st-cpr-start-others = {$performer} starts performing CPR on {$target}.
-st-cpr-success-performer = You perform CPR on {$target}. Repeat at least every {$seconds} seconds.
+st-cpr-success-performer = You perform CPR on {$target}.
 st-cpr-success-others = {$performer} performs CPR on {$target}.
-st-cpr-fail-self = You can't perform CPR on yourself!
 st-cpr-fail-rhythm = You fail to perform CPR on {$target}. Incorrect rhythm. Do it slower.
 st-cpr-fail-rhythm-others = {$performer} fails to perform CPR on {$target}!

--- a/Resources/Locale/ru-RU/_stalker/medical/cpr.ftl
+++ b/Resources/Locale/ru-RU/_stalker/medical/cpr.ftl
@@ -1,7 +1,6 @@
 st-cpr-start-performer = Вы начинаете делать искусственное дыхание {$target}.
 st-cpr-start-others = {$performer} начинает делать искусственное дыхание {$target}.
-st-cpr-success-performer = Вы делаете искусственное дыхание {$target}. Повторяйте как минимум каждые {$seconds} секунд.
+st-cpr-success-performer = Вы делаете искусственное дыхание {$target}.
 st-cpr-success-others = {$performer} делает искусственное дыхание {$target}.
-st-cpr-fail-self = Вы не можете делать искусственное дыхание самому себе!
 st-cpr-fail-rhythm = Вы не смогли сделать искусственное дыхание {$target}. Неправильный ритм. Делайте медленнее.
 st-cpr-fail-rhythm-others = {$performer} не смог сделать искусственное дыхание {$target}!


### PR DESCRIPTION
## What I changed

CPR self-interaction no longer blocks unbuckling or patting out fire when clicking on yourself
Removed the unnecessary "You can't perform CPR on yourself!" popup

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/464

## Changelog

author: @teecoding

- fix: Clicking on yourself no longer shows a CPR popup that blocks unbuckling and fire patting

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
