### PR TITLE
fix: resolve black screen freeze when opening character setup after death and body decomposition

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1159,6 +1159,7 @@ namespace Content.Client.Lobby.UI
             if (!disposing)
                 return;
 
+            _sponsors.SponsorSpeciesUpdated -= RefreshSpecies; // Stalker-Changes-Sponsors
             _loadoutWindow?.Dispose();
             _loadoutWindow = null;
         }

--- a/Content.Client/_RD/DeathScreen/RDDeathScreenControl.cs
+++ b/Content.Client/_RD/DeathScreen/RDDeathScreenControl.cs
@@ -33,6 +33,7 @@ public sealed class RDDeathScreenControl : RDControl
 
     private float _elapsedTime;
     private float _delayElapsedTime;
+    private bool _animationEnded; // stalker-en
 
     public RDDeathScreenControl()
     {
@@ -59,6 +60,7 @@ public sealed class RDDeathScreenControl : RDControl
 
         _elapsedTime = 0;
         _delayElapsedTime = 0;
+        _animationEnded = false; // stalker-en
     }
 
     protected override void FrameUpdate(FrameEventArgs args)
@@ -73,7 +75,12 @@ public sealed class RDDeathScreenControl : RDControl
                 return;
             }
 
-            OnAnimationEnd?.Invoke();
+            if (!_animationEnded) // stalker-en-start
+            {
+                _animationEnded = true;
+                OnAnimationEnd?.Invoke();
+            } // stalker-en-end
+
             return;
         }
 

--- a/Content.Client/_RD/DeathScreen/RDDeathScreenSystem.cs
+++ b/Content.Client/_RD/DeathScreen/RDDeathScreenSystem.cs
@@ -69,7 +69,10 @@ public sealed class RDDeathScreenSystem : EntitySystem
         }
 
         _ui.AnimationStart(ev);
-        _userInterface.RootControl.AddChild(_ui);
+        _remove = false; // stalker-en
+
+        if (!_userInterface.RootControl.Children.Contains(_ui)) // stalker-en
+            _userInterface.RootControl.AddChild(_ui);
     }
 
    /*

--- a/Content.Server/_Stalker_EN/RespawnConfirm/STRespawnConfirmSystem.cs
+++ b/Content.Server/_Stalker_EN/RespawnConfirm/STRespawnConfirmSystem.cs
@@ -96,6 +96,7 @@ public sealed class STRespawnConfirmSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<PlayerDetachedEvent>(OnPlayerDetached);
+        SubscribeLocalEvent<PlayerJoinedLobbyEvent>(OnPlayerJoinedLobby);
     }
 
     public override void Update(float frameTime)
@@ -123,6 +124,14 @@ public sealed class STRespawnConfirmSystem : EntitySystem
         // Clean up if player disconnects
         _openConfirms.Remove(args.Player);
         _pendingRespawns.Remove(args.Player);
+    }
+
+    private void OnPlayerJoinedLobby(PlayerJoinedLobbyEvent args)
+    {
+        // Ensure no stale pending respawn state remains when a player reaches the lobby
+        // (e.g., body decomposed while respawn was pending)
+        _openConfirms.Remove(args.PlayerSession);
+        _pendingRespawns.Remove(args.PlayerSession);
     }
 
     /// <summary>


### PR DESCRIPTION
## What I changed

Fixed a bug where opening the character customization tab after dying and having your body decompose would cause a black screen freeze, requiring a game restart.

Root cause: the sponsor species event handler was never unsubscribed when the character editor was disposed, so it fired on a dead UI control when re-entering the lobby.

Also fixed the death screen animation firing every frame after completing, and guarded against double-adding the death screen overlay. Added a safety net to clean up stale respawn state when a player joins the lobby.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/476

## Changelog

author: @teecoding

- fix: Fixed black screen freeze when opening character setup after dying and body decomposing

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
