### PR TITLE
fix: add weight thresholds to mutant mobs and show specimen weight on common throphies

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/boar.yml
@@ -93,7 +93,9 @@
     - type: StaminaDamageOnHit
       damage: 10
     - type: STWeight
-      self: 300
+      self: 140
+      overload: 238
+      maximum: 350
       # Stalker-EN start
     - type: STMobVariantConfig
       variants:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T1/flesh.yml
@@ -85,6 +85,8 @@
       damage: 7.5
     - type: STWeight
       self: 120
+      overload: 204
+      maximum: 300
     - type: InteractionPopup
       successChance: 0.9
       interactSuccessString: petting-success-flesh
@@ -218,6 +220,8 @@
       damage: 5
     - type: STWeight
       self: 120
+      overload: 204
+      maximum: 300
     - type: InteractionPopup
       successChance: 0.6
       interactSuccessString: petting-success-flesh

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/boar.yml
@@ -94,6 +94,8 @@
       damage: 10
     - type: STWeight
       self: 120
+      overload: 204
+      maximum: 300
     # Stalker-EN start
     - type: STMobVariantConfig
       variants:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/boar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/boar.yml
@@ -94,6 +94,8 @@
       damage: 10
     - type: STWeight
       self: 110
+      overload: 187
+      maximum: 275
     # Stalker-EN start
     - type: STMobVariantConfig
       variants:

--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/oracle.yml
@@ -107,3 +107,5 @@
           Piercing: -0.1
     - type: STWeight
       self: 100
+      overload: 170
+      maximum: 250


### PR DESCRIPTION
## What I changed

Mutant mobs whose body weight (`STWeight.self`) exceeded the default movement thresholds (`overload: 100`, `maximum: 200`) were being slowed or completely immobilized by their own weight. The T1 Boar (self: 300) could not move at all.

Added explicit `overload` and `maximum` values to affected mutant prototypes so their body weight no longer penalizes movement:

| Mutant | self | overload | maximum |
|---|---|---|---|
| T1 Boar | 140 | 238 | 300 |
| T2 Seasoned Boar | 120 | 204 | 300 |
| T3 Old Boar | 110 | 187 | 275 |
| T1 Flesh (both) | 120 | 204 | 300 |
| T3 Oracle | 100 | 170 | 250 |

Also fixed `STTrophyWeightSystem` so that common (non-variant) trophies now display the specimen's weight in the examine text. Previously only uncommon/rare/legendary trophies showed this.

## Changelog

author: @teecoding

- fix: Boars, flesh, and oracle mutants no longer get slowed or stuck due to their own body weight
- fix: Common trophies now display the specimen weight when examined

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
