### PR TITLE
fix: prevent black screen on reconnect after stash disconnect

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Map; // stalker-changes: nullspace check on reconnect
 using Robust.Shared.Utility;
 
 namespace Content.Server.GameTicking
@@ -95,9 +96,12 @@ namespace Content.Server.GameTicking
                         break;
                     }
 
-                    if (mind.CurrentEntity == null || Deleted(mind.CurrentEntity))
+                    // stalker-changes-start: prevent reattaching to entities in nullspace (causes black screen)
+                    if (mind.CurrentEntity == null || Deleted(mind.CurrentEntity)
+                        || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace)
+                    // stalker-changes-end
                     {
-                        DebugTools.Assert(mind.CurrentEntity == null, "a mind's current entity was deleted without updating the mind");
+                        DebugTools.Assert(mind.CurrentEntity == null || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace, "a mind's current entity was deleted without updating the mind"); // stalker-changes: allow nullspace assert
 
                         // This player is joining the game with an existing mind, but the mind has no entity.
                         // Their entity was probably deleted sometime while they were disconnected, or they were an observer.

--- a/Content.Server/_Stalker/Teleports/StalkerPortalSystem.cs
+++ b/Content.Server/_Stalker/Teleports/StalkerPortalSystem.cs
@@ -158,6 +158,28 @@ public sealed class StalkerPortalSystem : SharedTeleportSystem
                 }
             }
 
+            // stalker-changes-start: also check MAP children for minded entities
+            // TeleportEntity reparents players to the map, not the grid,
+            // so disconnected players in stash are missed by the grid child check above
+            if (!hasMind && TryComp<TransformComponent>(data.MapId, out var mapTransform))
+            {
+                var mapEnumerator = mapTransform.ChildEnumerator;
+                while (mapEnumerator.MoveNext(out var mapChild))
+                {
+                    if (_ent.HasComponent<MapGridComponent>(mapChild))
+                        continue;
+
+                    if (TryComp<MindContainerComponent>(mapChild, out var mapMind) && mapMind.HasMind
+                        && !HasComp<GhostComponent>(mapChild)
+                        && !HasComp<DatasetVocalizerComponent>(mapChild))
+                    {
+                        hasMind = true;
+                        break;
+                    }
+                }
+            }
+            // stalker-changes-end
+
             if (hasMind)
                 continue;
 


### PR DESCRIPTION
## What I changed

Players who disconnected while inside their personal stash would get a black screen when reconnecting later.

**Root cause:** When a player enters a stash, `TeleportEntity` reparents them to the MAP entity. But the arena cleanup (`OnClearArenaGrids`) only checks children of the GRID for minded entities. It misses the player, deletes the grid and map, and the player entity ends up orphaned in nullspace (MapId=0). On reconnect, the game reattaches the player to this broken entity, causing a black screen on the client.

**Fix (two changes):**

1. **GameTicker.Player.cs** - Added a nullspace safety net on reconnect. If a player's entity is in nullspace (MapId=0), spawn them as an observer instead of reattaching to the broken entity.

2. **StalkerPortalSystem.cs** - Fixed `OnClearArenaGrids` to also check MAP children (not just grid children) for minded entities. This prevents the arena from being deleted while a disconnected player's body is still on the map. When they reconnect, they resume in their stash.

## Changelog

author: @teecoding

- fix: Fixed black screen when reconnecting after disconnecting in stash

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
