### PR TITLE
fix: remove headers from zone names to render color markup in guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/Stalker14Rules/RuleC6.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/Stalker14Rules/RuleC6.xml
@@ -18,14 +18,14 @@
   - [color=#008000]The 100 Rads Bar[/color] in Rostok. [textlink="Duty" link="RuleF8"] controls Rostok. Any hostile or associated factions may be denied entry or engaged on sight within Rostok or the Bar. Enter at your own risk.
   - [color=#008000]Faction bases[/color]. Unless admin-approved for a raid.
 
-  ## [color=#808080]Gray Zone[/color]
+  [color=#808080]Gray Zone[/color]
 
   PvP and robbing are allowed only after there is an RP exchange in the encounter, if allowed depending on faction rules and faction relations.
 
   Locations:
   - Cordon (except the Southern Border — [textlink="Military" link="RuleF3"] can open fire on stalkers approaching the Southern Checkpoint).
 
-  ## [color=#4169E1]Faction Bases[/color]
+  [color=#4169E1]Faction Bases[/color]
 
   Faction base owners have the final say. They may use lethal force if the offender is violating their rules when appropriate or after escalation. You may also have to comply with reasonable requests — for example, while in government facilities, you may be detained or lose access for breaking the law.
 
@@ -33,14 +33,14 @@
   - Camping a faction base or its only access points is prohibited. Any faction that is hostile to the base-owning faction must remain at least 0.5 screens away.
   - Ignoring or resisting orders from faction members while in their base is prohibited.
 
-  ## [color=#FFFF00]Yellow Zones[/color]
+  [color=#FFFF00]Yellow Zones[/color]
 
   PvP and robbing are allowed depending on faction rules and faction relations. Factions at war are allowed to PvP on sight in a Yellow Zone.
 
   Locations:
   - Anything not specified in the other zones.
 
-  ## [color=#FF0000]Red Zones[/color]
+  [color=#FF0000]Red Zones[/color]
 
   On-sight PvP is allowed with neutral or hostile factions. Same faction members and allies of your faction should not be shot at.
 


### PR DESCRIPTION
## What I changed

Removed `##` from the zone title so they get colored properly 

## Changelog

author: @teecoding

- fix: Zone colors in the guidebook rules page now display correctly instead of showing raw markup text

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
