### PR TITLE
feat: engrave character name and age on dog tags at spawn

### DIFF
--- a/Content.Server/_Stalker_EN/DogTag/STDogTagInfoSystem.cs
+++ b/Content.Server/_Stalker_EN/DogTag/STDogTagInfoSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared._Stalker_EN.DogTag;
+using Content.Shared.GameTicking;
+using Content.Shared.Inventory;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Stalker_EN.DogTag;
+
+/// <summary>
+/// Stamps character identity information onto dog tags when players spawn.
+/// Listens to <see cref="PlayerSpawnCompleteEvent"/> and writes the character's
+/// name and age from their profile onto any dog tag in the neck slot.
+/// </summary>
+public sealed class STDogTagInfoSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly TagSystem _tags = default!;
+
+    private const string NeckSlot = "neck";
+    private static readonly ProtoId<TagPrototype> DogtagTag = "Dogtag";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+    }
+
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
+    {
+        if (!_inventory.TryGetSlotEntity(args.Mob, NeckSlot, out var neckEntity))
+            return;
+
+        if (!_tags.HasTag(neckEntity.Value, DogtagTag))
+            return;
+
+        var info = EnsureComp<STDogTagInfoComponent>(neckEntity.Value);
+        info.OwnerName = args.Profile.Name;
+        info.OwnerAge = args.Profile.Age;
+        Dirty(neckEntity.Value, info);
+    }
+}

--- a/Content.Shared/_Stalker_EN/DogTag/STDogTagInfoComponent.cs
+++ b/Content.Shared/_Stalker_EN/DogTag/STDogTagInfoComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Stalker_EN.DogTag;
+
+/// <summary>
+/// Stores the owner's identity information engraved on a dog tag at spawn time.
+/// Data is displayed when the dog tag is examined.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STDogTagInfoComponent : Component
+{
+    /// <summary>
+    /// The character name engraved on the dog tag.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string OwnerName = string.Empty;
+
+    /// <summary>
+    /// The character's age engraved on the dog tag.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int OwnerAge;
+}

--- a/Content.Shared/_Stalker_EN/DogTag/STDogTagInfoExamineSystem.cs
+++ b/Content.Shared/_Stalker_EN/DogTag/STDogTagInfoExamineSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Examine;
+
+namespace Content.Shared._Stalker_EN.DogTag;
+
+/// <summary>
+/// Displays the engraved owner name and age when a dog tag with
+/// <see cref="STDogTagInfoComponent"/> is examined.
+/// </summary>
+public sealed class STDogTagInfoExamineSystem : EntitySystem
+{
+    private const string LocExamineName = "st-dogtag-examine-name";
+    private const string LocExamineAge = "st-dogtag-examine-age";
+    private const string LocUnknown = "st-dogtag-examine-unknown";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<STDogTagInfoComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, STDogTagInfoComponent component, ExaminedEvent args)
+    {
+        var name = string.IsNullOrEmpty(component.OwnerName)
+            ? Loc.GetString(LocUnknown)
+            : component.OwnerName;
+
+        var age = component.OwnerAge > 0
+            ? component.OwnerAge.ToString()
+            : Loc.GetString(LocUnknown);
+
+        using (args.PushGroup(nameof(STDogTagInfoComponent)))
+        {
+            args.PushMarkup(Loc.GetString(LocExamineName, ("name", name)));
+            args.PushMarkup(Loc.GetString(LocExamineAge, ("age", age)));
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Stalker_EN/dogtag/dogtag-info.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/dogtag/dogtag-info.ftl
@@ -1,0 +1,3 @@
+st-dogtag-examine-name = [bold]Name:[/bold] {$name}
+st-dogtag-examine-age = [bold]Age:[/bold] {$age}
+st-dogtag-examine-unknown = Unknown

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Clothing/Neck/dogtags.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Clothing/Neck/dogtags.yml
@@ -1,5 +1,12 @@
 - type: entity
+  abstract: true
   parent: ClothingNeckDogtagBase
+  id: ClothingNeckDogtagBaseEN
+  components:
+  - type: STDogTagInfo
+
+- type: entity
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagLoner
   name: stalker dogtag
   description: A standard metal dogtag engraved with an identifier. A common sight in the zone.
@@ -14,7 +21,7 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagBandit
   name: bandit dogtag
   description: A dark steel dogtag decorated with a skull.
@@ -29,7 +36,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagBanditPahan
   name: bandit pahan dogtag
   description: A dark steel dogtag decorated with a skull wearing a crown.
@@ -44,7 +51,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagClearSky
   name: stalker dogtag
   description: A lightweight galvanized dogtag in pale blue, an image of the sun is pressed into it.
@@ -59,7 +66,7 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagClearSkyLeader
   name: stalker dogtag
   description: A lightweight galvanized dogtag in pale blue, an image of the sun is pressed into it and small, intricate birds decorate the back.
@@ -74,10 +81,10 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagDuty
   name: duty dogtag
-  description: A durable reddog tag with a black rubber sleeve, an identifier is carved into it.
+  description: A durable red dogtag with a black rubber sleeve, an identifier is carved into it.
   suffix: ST, Duty
   components:
   - type: Sprite
@@ -89,10 +96,10 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagDutyCommander
   name: duty commander dogtag
-  description: A durable reddog tag with a black rubber sleeve, a military rank and identifier are carved into it.
+  description: A durable red dogtag with a black rubber sleeve, a military rank and identifier are carved into it.
   suffix: ST, Duty
   components:
   - type: Sprite
@@ -104,7 +111,7 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagEco
   name: scientist dogtag
   description: A clean steel dogtag with a blue and red flask on the front and a barcode on the back.
@@ -119,7 +126,7 @@
       PremiumSupplyTalons: 0
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagEcoLeader
   name: scientist leader dogtag
   description: A clean steel dogtag with a blue and red flask overlayed with the Ukrainian flag. A barcode is printed on the back.
@@ -134,7 +141,7 @@
       PremiumSupplyTalons: 0
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagFreedom
   name: freedom dogtag
   description: A dented metal dogtag with a dog crudely carved into it.
@@ -149,7 +156,7 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagFreedomAtaman
   name: freedom ataman dogtag
   description: A dented metal dogtag with a dog crudely carved into it. It's been carefully painted.
@@ -164,22 +171,22 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagJournalist
   name: press ID
   description: A laminated ID designating the owner as a reporter.
   suffix: ST, Journalist
   components:
-    - type: Sprite
-      sprite: _Stalker_EN/Objects/Clothing/Neck/Dogtags/journalist.rsi
-    - type: TypingIndicatorClothing
-      proto: journalist
-    - type: Currency
-      price:
-        PremiumSupplyTalons: 1
+  - type: Sprite
+    sprite: _Stalker_EN/Objects/Clothing/Neck/Dogtags/journalist.rsi
+  - type: TypingIndicatorClothing
+    proto: journalist
+  - type: Currency
+    price:
+      PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagMercenary
   name: mercenary dogtag
   description: A lightweight dogtag in dark blue with identifying numbers carved into it.
@@ -194,7 +201,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagMercenaryCommander
   name: mercenary commander dogtag
   description: A lightweight dogtag in dark blue with identifying numbers carved into it. It's dented and scratched.
@@ -209,7 +216,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagMilitary
   name: military dogtag
   description: A military dogtag in standard green, a rank and identifying number has been engraved into it.
@@ -224,7 +231,7 @@
       PremiumSupplyTalons: 0
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagMilitaryCommander
   name: military commander dogtag
   description: A military dogtag in standard green, a rank and identifying number has been engraved into it.
@@ -239,7 +246,7 @@
       PremiumSupplyTalons: 0
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagMonolith
   name: monolith dogtag
   description: A pale white dogtag with no identifying features.
@@ -254,7 +261,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagNeutral
   name: neutral dogtag
   description: A metal dogtag on a reflective yellow lanyard, a blue free stalker symbol had been pressed into it.
@@ -269,7 +276,7 @@
       PremiumSupplyTalons: 1
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagRenegade
   name: renegade dogtag
   description: A dogtag caked in mud and grime, it's decorated with a gold and green scorpion.
@@ -284,7 +291,7 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagRenegadeLeader
   name: renegade leader dogtag
   description: A dogtag caked in blood, it's decorated with a gold and green scorpion.
@@ -299,10 +306,10 @@
       PremiumSupplyTalons: 2
 
 - type: entity
-  parent: ClothingNeckDogtagBase
+  parent: ClothingNeckDogtagBaseEN
   id: ClothingNeckDogtagRookie
   name: rookie dogtag
-  description: A scratched, unmarked dogtag given to newcomers in the Zone. Sidorovich won't engrave a real Loner tag until you've proven you can survive.
+  description: A scratched dogtag given to newcomers in the Zone. It's seen better days.
   suffix: ST, Stalkers, Rookie
   components:
   - type: Sprite


### PR DESCRIPTION
## What I changed

Dog tags now display the owner's character name and age when examined. If a dog tag is spawned by a GM without a player (e.g. admin spawn), it shows "Unknown" for both fields.

Also added an abstract EN base dog tag prototype so all EN dog tags inherit the new component, and updated the rookie dog tag description to remove the "unmarked" reference.

## Changelog

author: @teecoding

- add: Dog tags now show the owner's name and age when examined

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
