### PR TITLE
fix: disable quick-equip on STRadioHeadset to prevent UI conflict

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Clothing/Ears/radio_headset.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Clothing/Ears/radio_headset.yml
@@ -16,6 +16,7 @@
   - type: Speech
     speechVerb: Robotic
   - type: Clothing
+    quickEquip: false
     slots: [ears]
     sprite: _Stalker_EN/Objects/Clothing/Ears/radio_headset.rsi
   - type: Item


### PR DESCRIPTION
## What I changed

Added `quickEquip: false` to the STRadioHeadset's `Clothing` component, same fix that was applied to PDAs previously. Players can still equip the headset via the inventory UI, right-click, or drag-and-drop.

## Changelog

author: @teecoding

- fix: Radio headset no longer auto-equips when trying to open its frequency UI

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license