### PR TITLE
fix: prevent personal stash UI from opening when inserting item with interact

### DIFF
--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -387,7 +387,10 @@ public sealed class StalkerRepositorySystem : EntitySystem
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"Player {Name(args.User):user} inserted 1 {itemInfo.Name} into repository");
         _stalkerStorageSystem.SaveStorage(component);
         RaiseLocalEvent(args.User, new RepositoryItemInjectedEvent(args.Target, itemInfo));
-        UpdateUiState(args.User, uid, component);
+        // stalker-changes: only update UI if already open, don't open it just from inserting an item
+        if (_ui.IsUiOpen(uid, StalkerRepositoryUiKey.Key, args.User))
+            UpdateUiState(args.User, uid, component);
+
         _loadoutSystem.SendLoadoutStateUpdate(uid, component, args.User);
     }
 


### PR DESCRIPTION
## What I changed

Clicking on the personal stash with an item in hand now only stores the item without opening the stash UI. Previously it would both store the item and open the UI. The stash UI now only opens when clicking with an empty hand.

## Changelog

author: @teecoding

- fix: Personal stash no longer opens its UI when storing an item by clicking with it

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license