### PR TITLE
feat: add anomaly regeneration during emissions

### DIFF
--- a/Content.Server/_Stalker/Anomaly/Generation/Systems/STAnomalyGeneratorSystem.cs
+++ b/Content.Server/_Stalker/Anomaly/Generation/Systems/STAnomalyGeneratorSystem.cs
@@ -94,7 +94,8 @@ public sealed partial class STAnomalyGeneratorSystem : EntitySystem
         _jobs.Clear();
     }
 
-    private async Task<STAnomalyGenerationJobData> StartGeneration(MapId mapId, STAnomalyGenerationOptions options)
+    // stalker-en-changes: made public for emission anomaly regeneration
+    public async Task<STAnomalyGenerationJobData> StartGeneration(MapId mapId, STAnomalyGenerationOptions options)
     {
         var cancelToken = new CancellationTokenSource();
         var job = new STAnomalyGenerationJob(options with { MapId = mapId }, JobTime, cancelToken.Token);
@@ -119,7 +120,8 @@ public sealed partial class STAnomalyGeneratorSystem : EntitySystem
         return job.Result!;
     }
 
-    private void ClearGeneration(MapId mapId)
+    // stalker-en-changes: made public for emission anomaly regeneration
+    public void ClearGeneration(MapId mapId)
     {
         if (!Data.Comp.MapGeneratedAnomalies.TryGetValue(mapId, out var anomalies))
             return;

--- a/Content.Server/_Stalker_EN/Emission/EmissionAnomalyRegenComponent.cs
+++ b/Content.Server/_Stalker_EN/Emission/EmissionAnomalyRegenComponent.cs
@@ -1,0 +1,83 @@
+using Content.Shared._Stalker.Anomaly.Prototypes;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Stalker_EN.Emission;
+
+/// <summary>
+/// Phase of the anomaly regeneration state machine during an emission.
+/// </summary>
+public enum EmissionRegenPhase : byte
+{
+    Idle,
+    WaitingForDeletion,
+    Deleting,
+    WaitingForRegeneration,
+    Regenerating,
+    Complete,
+}
+
+/// <summary>
+/// Added to the emission game rule entity to enable anomaly deletion and regeneration during emissions.
+/// Orchestrates staggered per-map deletion during Stage 2 and staggered regeneration during Stage 3.
+/// </summary>
+[RegisterComponent, Access(typeof(STEmissionAnomalyRegenSystem))]
+public sealed partial class EmissionAnomalyRegenComponent : Component
+{
+    /// <summary>
+    /// Delay after Stage 2 starts before anomaly deletion begins.
+    /// </summary>
+    [DataField]
+    public TimeSpan DeletionDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Delay between deleting anomalies on consecutive maps.
+    /// </summary>
+    [DataField]
+    public TimeSpan DeletionStaggerInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Delay after all deletions complete before anomaly regeneration begins.
+    /// </summary>
+    [DataField]
+    public TimeSpan RegenerationDelay = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Delay between starting regeneration on consecutive maps.
+    /// </summary>
+    [DataField]
+    public TimeSpan RegenerationStaggerInterval = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Whether anomaly regeneration is enabled. Can be toggled per emission event in YAML.
+    /// </summary>
+    [DataField]
+    public bool Enabled = true;
+
+    // Runtime state -- not serialized, not networked.
+
+    /// <summary>
+    /// Current phase of the anomaly regeneration state machine.
+    /// </summary>
+    public EmissionRegenPhase Phase = EmissionRegenPhase.Idle;
+
+    /// <summary>
+    /// Absolute time of the next stagger action (deletion or regeneration step).
+    /// </summary>
+    public TimeSpan NextAction;
+
+    /// <summary>
+    /// Ordered list of maps whose anomalies remain to be deleted.
+    /// </summary>
+    public List<MapId> PendingDeletionMaps = new();
+
+    /// <summary>
+    /// Ordered list of maps with their generation options, awaiting anomaly regeneration.
+    /// </summary>
+    public List<(MapId MapId, ProtoId<STAnomalyGenerationOptionsPrototype> OptionsId)> PendingRegenerationMaps = new();
+
+    /// <summary>
+    /// Index into the current pending list (deletion or regeneration) being processed.
+    /// </summary>
+    public int CurrentMapIndex;
+}

--- a/Content.Server/_Stalker_EN/Emission/STEmissionAnomalyRegenSystem.cs
+++ b/Content.Server/_Stalker_EN/Emission/STEmissionAnomalyRegenSystem.cs
@@ -1,0 +1,166 @@
+using System.Threading.Tasks;
+using Content.Server._Stalker.Anomaly.Generation.Components;
+using Content.Server._Stalker.Anomaly.Generation.Systems;
+using Content.Shared._Stalker.Anomaly.Prototypes;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Stalker_EN.Emission;
+
+/// <summary>
+/// Orchestrates staggered anomaly deletion and regeneration during emissions.
+/// Deletion begins during Stage 2 (while players shelter), regeneration begins after
+/// all deletions complete (typically during Stage 3). Maps are processed one at a time
+/// with configurable stagger intervals to prevent tick spikes.
+/// </summary>
+public sealed class STEmissionAnomalyRegenSystem : EntitySystem
+{
+    [Dependency] private readonly STAnomalyGeneratorSystem _anomalyGenerator = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<EmissionAnomalyRegenComponent, EmissionEventRuleComponent>();
+        while (query.MoveNext(out _, out var regen, out var emission))
+        {
+            if (!regen.Enabled)
+                continue;
+
+            ProcessPhase(regen, emission);
+        }
+    }
+
+    private void ProcessPhase(EmissionAnomalyRegenComponent regen, EmissionEventRuleComponent emission)
+    {
+        switch (regen.Phase)
+        {
+            case EmissionRegenPhase.Idle:
+                if (emission.Stage == EmissionStage.Stage2)
+                {
+                    regen.Phase = EmissionRegenPhase.WaitingForDeletion;
+                    regen.NextAction = _timing.CurTime + regen.DeletionDelay;
+                    BuildMapLists(regen);
+                    Log.Info("Emission anomaly regen: entering deletion wait phase");
+                }
+                break;
+
+            case EmissionRegenPhase.WaitingForDeletion:
+                if (_timing.CurTime >= regen.NextAction)
+                {
+                    regen.Phase = EmissionRegenPhase.Deleting;
+                    regen.CurrentMapIndex = 0;
+                    regen.NextAction = _timing.CurTime;
+                }
+                break;
+
+            case EmissionRegenPhase.Deleting:
+                ProcessDeletion(regen);
+                break;
+
+            case EmissionRegenPhase.WaitingForRegeneration:
+                if (_timing.CurTime >= regen.NextAction)
+                {
+                    regen.Phase = EmissionRegenPhase.Regenerating;
+                    regen.CurrentMapIndex = 0;
+                    regen.NextAction = _timing.CurTime;
+                }
+                break;
+
+            case EmissionRegenPhase.Regenerating:
+                ProcessRegeneration(regen);
+                break;
+
+            case EmissionRegenPhase.Complete:
+                break;
+        }
+    }
+
+    private void ProcessDeletion(EmissionAnomalyRegenComponent regen)
+    {
+        if (_timing.CurTime < regen.NextAction)
+            return;
+
+        if (regen.CurrentMapIndex < regen.PendingDeletionMaps.Count)
+        {
+            var mapId = regen.PendingDeletionMaps[regen.CurrentMapIndex];
+            _anomalyGenerator.ClearGeneration(mapId);
+            regen.CurrentMapIndex++;
+            regen.NextAction = _timing.CurTime + regen.DeletionStaggerInterval;
+            Log.Info($"Emission anomaly regen: cleared map {mapId} ({regen.CurrentMapIndex}/{regen.PendingDeletionMaps.Count})");
+        }
+        else
+        {
+            regen.Phase = EmissionRegenPhase.WaitingForRegeneration;
+            regen.NextAction = _timing.CurTime + regen.RegenerationDelay;
+            Log.Info("Emission anomaly regen: all maps cleared, waiting for regeneration phase");
+        }
+    }
+
+    private void ProcessRegeneration(EmissionAnomalyRegenComponent regen)
+    {
+        if (_timing.CurTime < regen.NextAction)
+            return;
+
+        if (regen.CurrentMapIndex < regen.PendingRegenerationMaps.Count)
+        {
+            var (mapId, optionsProtoId) = regen.PendingRegenerationMaps[regen.CurrentMapIndex];
+
+            if (_prototype.TryIndex(optionsProtoId, out var optionsProto))
+            {
+                _ = _anomalyGenerator.StartGeneration(mapId, optionsProto.Options).ContinueWith(
+                    t => Log.Error($"Emission anomaly regen: generation failed for map {mapId}: {t.Exception}"),
+                    TaskContinuationOptions.OnlyOnFaulted);
+                Log.Info($"Emission anomaly regen: started generation on map {mapId} ({regen.CurrentMapIndex + 1}/{regen.PendingRegenerationMaps.Count})");
+            }
+            else
+            {
+                Log.Warning($"Emission anomaly regen: failed to index options prototype '{optionsProtoId}' for map {mapId}");
+            }
+
+            regen.CurrentMapIndex++;
+            regen.NextAction = _timing.CurTime + regen.RegenerationStaggerInterval;
+        }
+        else
+        {
+            regen.Phase = EmissionRegenPhase.Complete;
+            Log.Info("Emission anomaly regen: all maps queued for regeneration");
+        }
+    }
+
+    /// <summary>
+    /// Builds the ordered list of maps to delete/regenerate from STAnomalyGeneratorTargetComponent entities.
+    /// Sorts smaller maps first to spread load (small maps finish faster).
+    /// </summary>
+    private void BuildMapLists(EmissionAnomalyRegenComponent regen)
+    {
+        regen.PendingDeletionMaps.Clear();
+        regen.PendingRegenerationMaps.Clear();
+
+        var query = EntityQueryEnumerator<MapComponent, STAnomalyGeneratorTargetComponent>();
+        var entries = new List<(MapId MapId, ProtoId<STAnomalyGenerationOptionsPrototype> OptionsId, int TotalCount)>();
+
+        while (query.MoveNext(out _, out var mapComp, out var target))
+        {
+            if (!_prototype.TryIndex(target.OptionsId, out var optionsProto))
+                continue;
+
+            entries.Add((mapComp.MapId, target.OptionsId, optionsProto.Options.TotalCount));
+        }
+
+        // Sort by TotalCount ascending -- delete and regenerate small maps first
+        entries.Sort((a, b) => a.TotalCount.CompareTo(b.TotalCount));
+
+        foreach (var (mapId, optionsId, _) in entries)
+        {
+            regen.PendingDeletionMaps.Add(mapId);
+            regen.PendingRegenerationMaps.Add((mapId, optionsId));
+        }
+
+        Log.Info($"Emission anomaly regen: found {entries.Count} maps to regenerate");
+    }
+}

--- a/Resources/Prototypes/_Stalker_EN/GameRules/emission_events.yml
+++ b/Resources/Prototypes/_Stalker_EN/GameRules/emission_events.yml
@@ -56,6 +56,11 @@
     lightningSpawnRadius: 17.5 # slightly smaller than PVS range which is 25
     lightningIntervalRange: 4, 15
     lightningEffectProtoId: EmissionLightningEffect
+  - type: EmissionAnomalyRegen
+    deletionDelay: 30               # 30s after Stage 2 starts
+    deletionStaggerInterval: 5      # 5s between each map's deletion
+    regenerationDelay: 10           # 10s after all deletions complete
+    regenerationStaggerInterval: 15  # 15s between each map's regen start
 
 - type: entity
   parent: STEmissionEvent
@@ -70,3 +75,8 @@
     damageStartDelay: 15   # Damage begins
     redHueBeforeEndDelay: 30
     damageEndDelay: 50     # Damage ends, stage 3 plays, red hue clears
+  - type: EmissionAnomalyRegen
+    deletionDelay: 5
+    deletionStaggerInterval: 1
+    regenerationDelay: 3
+    regenerationStaggerInterval: 3


### PR DESCRIPTION
## What I changed

Emissions now delete all existing anomalies and regenerate them in new random positions. Deletion happens during Stage 2 (while players are sheltering) and regeneration starts during Stage 3 (recovery). Maps are processed one at a time with configurable stagger intervals to avoid server lag.

New `EmissionAnomalyRegen` component on the emission game rule entity controls all timing via YAML. Debug emission variant has faster timers for testing.

## Changelog

author: @teecoding

- add: Emissions now reshuffle all anomalies across the map, placing them in new random locations after each emission

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/stalker14-project/stalker-14/edit/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
