### PR TITLE
fix: adjust day/night ratio to 66/33 and fix emission stuck red lighting

### DIFF
--- a/Content.Server/_Stalker_EN/Emission/EmissionEventRuleSystem.cs
+++ b/Content.Server/_Stalker_EN/Emission/EmissionEventRuleSystem.cs
@@ -205,16 +205,16 @@ public sealed class EmissionEventRuleSystem : StationEventSystem<EmissionEventRu
         var query = EntityQueryEnumerator<MapLightComponent>();
         while (query.MoveNext(out var mapUid, out _))
         {
-            var mapActiveEmissionComponent = EntityManager.ComponentFactory.GetComponent<MapActiveEmissionComponent>();
-            mapActiveEmissionComponent.PrimaryEmissionColor = emissionRuleComponent.PrimaryEmissionColor;
-            mapActiveEmissionComponent.SecondaryEmissionColor = emissionRuleComponent.SecondaryEmissionColor;
+            var comp = EnsureComp<MapActiveEmissionComponent>(mapUid);
+            comp.PrimaryEmissionColor = emissionRuleComponent.PrimaryEmissionColor;
+            comp.SecondaryEmissionColor = emissionRuleComponent.SecondaryEmissionColor;
+            comp.Deviation = 1f; // Reset in case component already existed from a previous emission
 
-            mapActiveEmissionComponent.TotalDeviationDecreaseStartTime = emissionRuleComponent.EventStartTime + emissionRuleComponent.RedHueBeforeEndDelay;
-            mapActiveEmissionComponent.TotalDeviationDecreaseRate =
-                mapActiveEmissionComponent.Deviation / (float)(emissionRuleComponent.DamageEndDelay - emissionRuleComponent.RedHueBeforeEndDelay).TotalSeconds;
+            comp.TotalDeviationDecreaseStartTime = emissionRuleComponent.EventStartTime + emissionRuleComponent.RedHueBeforeEndDelay;
+            comp.TotalDeviationDecreaseRate =
+                comp.Deviation / (float)(emissionRuleComponent.DamageEndDelay - emissionRuleComponent.RedHueBeforeEndDelay).TotalSeconds;
 
-            AddComp(mapUid, mapActiveEmissionComponent);
-            Dirty(mapUid, mapActiveEmissionComponent);
+            Dirty(mapUid, comp);
         }
     }
 

--- a/Content.Shared/Light/EntitySystems/SharedLightCycleSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedLightCycleSystem.cs
@@ -65,7 +65,7 @@ public abstract class SharedLightCycleSystem : EntitySystem
         var waveLength = MathF.Max(1, (float) comp.Duration.TotalSeconds);
         var crest = MathF.Max(0f, comp.MaxLightLevel);
         var shift = MathF.Max(0f, comp.MinLightLevel);
-        return Math.Min(comp.ClipLight, CalculateCurve(time, waveLength, crest, shift, 6));
+        return Math.Min(comp.ClipLight, CalculateCurve(time, waveLength, crest, shift, 4)); // stalker-changes: 6 -> 4 for ~66% day
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public abstract class SharedLightCycleSystem : EntitySystem
                 waveLength,
                 MathF.Max(0f, comp.MaxLevel.G),
                 MathF.Max(0f, comp.MinLevel.G),
-                8f)); // Stalker-Changes: Before it was 10f, but was replaced to modify the curve so we can adapt it to the longer days
+                4f)); // Stalker-Changes: 10f -> 8f -> 4f to achieve ~66% day / ~33% night
 
         var blue = MathF.Min(comp.ClipLevel.B,
             CalculateBlueWithGapControl(time, // Stalker-Changes: CalculateCurve doesn't fit if we need to make days longer, so as the distance for gaps for this function


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

**Day/Night Cycle Ratio (66/33)**

Adjusted the light level and green color curve exponents in `SharedLightCycleSystem` so that daytime now takes roughly 66% of the cycle instead of 50%. The green channel was the perceptual bottleneck -- at exponent 8 it only reached full brightness for half the cycle despite previous tuning attempts. Lowering both the light level exponent (6 to 4) and green exponent (8 to 4) gives approximately 60 minutes of day and 30 minutes of night per 90-minute cycle.

**Fix Maps Getting Stuck Red After Emissions**

Replaced the fragile `ComponentFactory.GetComponent` + `AddComp` pattern in `EmissionEventRuleSystem.SetAmbientLightColor` with `EnsureComp`. The old code threw an exception if `MapActiveEmissionComponent` already existed on the map entity (e.g. from a deferred removal not yet culled), which left `LightCycleComponent.Enabled` stuck at `false` and `MapDaySystem` disabled permanently.

Also expanded `MapDayRoundResetSystem` to fully clean up all lighting state on round restart: removes lingering `MapActiveEmissionComponent`, re-enables `LightCycleComponent`, and restores original colors and min levels. This acts as a safety net covering both emission and anomaly explosion edge cases.

## Changelog

author: @teecoding

- tweak: Daytime now lasts roughly twice as long as nighttime instead of being an even split
- fix: Fixed maps sometimes getting permanently stuck with red lighting after an emission

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
