### PR TITLE
fix: separate bear HTN idle branch from roar-restore to allow roaming

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/HTNs/Mutants/bear.yml
+++ b/Resources/Prototypes/_Stalker_EN/HTNs/Mutants/bear.yml
@@ -7,6 +7,7 @@
   - tasks:
     - !type:HTNCompoundTask
       task: STBearRoarRestoreCompound
+  - tasks:
     - !type:HTNCompoundTask
       task: IdleCompound
 

--- a/Resources/Prototypes/_Stalker_EN/HTNs/Mutants/bear_t3.yml
+++ b/Resources/Prototypes/_Stalker_EN/HTNs/Mutants/bear_t3.yml
@@ -7,6 +7,7 @@
   - tasks:
     - !type:HTNCompoundTask
       task: STBearT3RoarRestoreCompound
+  - tasks:
     - !type:HTNCompoundTask
       task: IdleCompound
 


### PR DESCRIPTION
## What I changed

Fixed bears being stuck in place after spawning. Bears were not roaming or idling when no players were nearby because the HTN idle branch was blocked by a roar-restore precondition that always failed at spawn. Split the roar-restore and idle into separate HTN branches so idle behavior is always reachable as a fallback.

## Changelog

author: @teecoding

- fix: Bears now properly roam and idle when no players are nearby instead of standing still after spawning

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
