### PR TITLE
fix: increase green exponent to 6f to prevent green sky during dawn/dusk transitions

### DIFF
--- a/Content.Shared/Light/EntitySystems/SharedLightCycleSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedLightCycleSystem.cs
@@ -91,7 +91,7 @@ public abstract class SharedLightCycleSystem : EntitySystem
                 waveLength,
                 MathF.Max(0f, comp.MaxLevel.G),
                 MathF.Max(0f, comp.MinLevel.G),
-                4f)); // Stalker-Changes: 10f -> 8f -> 4f to achieve ~66% day / ~33% night
+                6f)); // Stalker-Changes: 10f -> 8f -> 6f; higher exponent than red ensures green lags during dawn/dusk for warm transitions
 
         var blue = MathF.Min(comp.ClipLevel.B,
             CalculateBlueWithGapControl(time, // Stalker-Changes: CalculateCurve doesn't fit if we need to make days longer, so as the distance for gaps for this function


### PR DESCRIPTION
## What I changed

Fixed the green sky tint during dawn/dusk transitions in the day/night cycle. A previous commit reduced the green color channel exponent to match red (4f), but green has a higher max amplitude (14f vs 9f), causing it to dominate during transitions. Increased the green exponent to 6f so green rises later and falls earlier than red, producing natural warm dawn/dusk tones without affecting the 66% day / 33% night ratio.

## Changelog

author: @teecoding

- fix: Fixed sky appearing too green during dawn and dusk transitions

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
