### PR TITLE
feat: add dedicated dogtag inventory slot separate from neck

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -48,7 +48,8 @@ public sealed class ClientClothingSystem : ClothingSystem
         {"legs", "LEGS"},
         {"cloak", "CLOAK"},
         {"torso", "TORSO" },
-        {"dopweapon", "BACKPACK"}
+        {"dopweapon", "BACKPACK"},
+        {"dogtag", "NECK"},
         // stalke-changes-ends
     };
 

--- a/Content.Server/_Stalker_EN/DogTag/STDogTagInfoSystem.cs
+++ b/Content.Server/_Stalker_EN/DogTag/STDogTagInfoSystem.cs
@@ -9,14 +9,14 @@ namespace Content.Server._Stalker_EN.DogTag;
 /// <summary>
 /// Stamps character identity information onto dog tags when players spawn.
 /// Listens to <see cref="PlayerSpawnCompleteEvent"/> and writes the character's
-/// name and age from their profile onto any dog tag in the neck slot.
+/// name and age from their profile onto any dog tag in the dogtag slot.
 /// </summary>
 public sealed class STDogTagInfoSystem : EntitySystem
 {
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly TagSystem _tags = default!;
 
-    private const string NeckSlot = "neck";
+    private const string DogtagSlot = "dogtag";
     private static readonly ProtoId<TagPrototype> DogtagTag = "Dogtag";
 
     public override void Initialize()
@@ -28,15 +28,15 @@ public sealed class STDogTagInfoSystem : EntitySystem
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent args)
     {
-        if (!_inventory.TryGetSlotEntity(args.Mob, NeckSlot, out var neckEntity))
+        if (!_inventory.TryGetSlotEntity(args.Mob, DogtagSlot, out var dogtagEntity))
             return;
 
-        if (!_tags.HasTag(neckEntity.Value, DogtagTag))
+        if (!_tags.HasTag(dogtagEntity.Value, DogtagTag))
             return;
 
-        var info = EnsureComp<STDogTagInfoComponent>(neckEntity.Value);
+        var info = EnsureComp<STDogTagInfoComponent>(dogtagEntity.Value);
         info.OwnerName = args.Profile.Name;
         info.OwnerAge = args.Profile.Age;
-        Dirty(neckEntity.Value, info);
+        Dirty(dogtagEntity.Value, info);
     }
 }

--- a/Content.Shared/Inventory/SlotFlags.cs
+++ b/Content.Shared/Inventory/SlotFlags.cs
@@ -30,6 +30,7 @@ public enum SlotFlags
     ARTIFACT = 1 << 17, // Stalker-Changes-UI
     BACK2 = 1 << 18, // Stalker-Changes-UI
     CLOAK = 1 << 19, // Stalker-Changes-UI
+    DOGTAG = 1 << 20, // Stalker-Changes-UI
     All = ~NONE,
 
     WITHOUT_POCKET = All & ~POCKET

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -42,6 +42,7 @@
     - map: [ "cloak" ] # stalker-changes
     - map: [ "back" ]
     - map: [ "neck" ]
+    - map: [ "dogtag" ] # stalker-changes
     - map: [ "enum.HumanoidVisualLayers.SnoutCover" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
@@ -361,6 +362,7 @@
     - map: [ "cloak" ] # stalker-changes
     - map: [ "back" ]
     - map: [ "neck" ]
+    - map: [ "dogtag" ] # stalker-changes
     - map: [ "enum.HumanoidVisualLayers.SnoutCover" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Neck/dogtags.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Neck/dogtags.yml
@@ -6,6 +6,9 @@
   name: жетон
   description: стандартный жетон
   components:
+  - type: Clothing
+    slots:
+    - dogtag
   - type: StealTarget
     stealGroup: HeadCloak
   # need this to be able to insert it back in PDA

--- a/Resources/Prototypes/_Stalker/InventoryTemplates/stalker_template.yml
+++ b/Resources/Prototypes/_Stalker/InventoryTemplates/stalker_template.yml
@@ -173,6 +173,16 @@
       uiWindowPos: 3,0
       strippingWindowPos: 3,4
       displayName: Cloak
+    - name: dogtag
+      slotTexture: neck
+      slotFlags: DOGTAG
+      stripTime: 3
+      uiWindowPos: 3,1
+      strippingWindowPos: 2,1
+      displayName: Dogtag
+      whitelist:
+        tags:
+          - Dogtag
     - name: back2
       slotTexture: suit_storage
       slotFlags: BACK2

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/Evolvers/pack.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/Evolvers/pack.yml
@@ -85,7 +85,7 @@
   id: STEvolverPackAlphaGear
   equipment:
     id: BandPDA
-    neck: ClothingNeckDogtagBrigand
+    dogtag: ClothingNeckDogtagBrigand
     eyes: ClothingEyesGlassesSunglasses
     torso: STClothingTorsoJacketGray
     legs: STClothingLegsPantsGray

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/bands.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/bands.yml
@@ -82,12 +82,12 @@
   id: BandGear
   equipment:
     id: BandPDA
-    neck: ClothingNeckDogtagBandit
+    dogtag: ClothingNeckDogtagBandit
 - type: startingGear
   id: BandHeadGear
   equipment:
     id: BandPDA
-    neck: ClothingNeckDogtagBanditPahan # EN
+    dogtag: ClothingNeckDogtagBanditPahan # EN
 
 - type: stBand
   id: STBanditsBand

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/clear_sky.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/clear_sky.yml
@@ -84,13 +84,13 @@
   id: StalkerClearSkyGear
   equipment:
     id: ClearSkyPDA
-    neck: ClothingNeckDogtagClearSky
+    dogtag: ClothingNeckDogtagClearSky
 
 - type: startingGear
   id: StalkerClearSkyGearHead
   equipment:
     id: ClearSkyPDA
-    neck: ClothingNeckDogtagClearSkyLeader
+    dogtag: ClothingNeckDogtagClearSkyLeader
 
 - type: stBand
   id: STClearSkyBand

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/dolg.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/dolg.yml
@@ -82,13 +82,13 @@
   id: DolgGear
   equipment:
     id: DolgPDA
-    neck: ClothingNeckDogtagDuty
+    dogtag: ClothingNeckDogtagDuty
 
 - type: startingGear
   id: DolgGearHead
   equipment:
     id: DolgPDA
-    neck: ClothingNeckDogtagDutyCommander
+    dogtag: ClothingNeckDogtagDutyCommander
 
 - type: stBand
   id: STDolgBand

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/freedom.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/freedom.yml
@@ -82,13 +82,13 @@
   id: FreedomGear
   equipment:
     id: FreedomPDA
-    neck: ClothingNeckDogtagFreedom # EN
+    dogtag: ClothingNeckDogtagFreedom # EN
 
 - type: startingGear
   id: FreedomGearHead
   equipment:
     id: FreedomPDA
-    neck: ClothingNeckDogtagFreedomAtaman # EN
+    dogtag: ClothingNeckDogtagFreedomAtaman # EN
 
 - type: stBand
   id: STFreedomBand

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/journalists.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/journalists.yml
@@ -40,7 +40,7 @@
   id: JurGear
   equipment:
     id: StalkerPDA
-    neck: ClothingNeckDogtagJournalist # EN
+    dogtag: ClothingNeckDogtagJournalist # EN
     torso: ClothingTorsoSweaterStalkerGreen
     legs: ClothingLegsJeansBlue
     shoes: STClothingShoesBootsCombatFilled

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/mercenaries.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/mercenaries.yml
@@ -38,7 +38,7 @@
   id: StalkerMercenaryGear
   equipment:
     id: MercPDA
-    neck: ClothingNeckDogtagMercenary # EN
+    dogtag: ClothingNeckDogtagMercenary # EN
     torso: STClothingTorsoJacketGray
     legs: STClothingLegsPantsGray
     shoes: ClothingShoesSwat
@@ -85,7 +85,7 @@
   id: StalkerHeadMercenaryGear
   equipment:
     id: MercPDA
-    neck: ClothingNeckDogtagMercenaryCommander # EN
+    dogtag: ClothingNeckDogtagMercenaryCommander # EN
     eyes: ClothingEyesGlassesSunglasses
     torso: STClothingTorsoJacketGray
     legs: STClothingLegsPantsGray

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/militaries.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/militaries.yml
@@ -209,7 +209,7 @@
     torso: ClothingTorsoTurtlenecksUa
     shoes: STClothingShoesBootsCombatFilled
     id: STOKSOPPdaEN
-    neck: ClothingNeckDogtagMilitary # EN
+    dogtag: ClothingNeckDogtagMilitary # EN
 
 - type: startingGear
   id: MilitaryGearOfficer
@@ -218,7 +218,7 @@
     torso: ClothingTorsoTurtlenecksMilitary
     shoes: STClothingShoesBootsCombatFilled
     id: STOKSOPPdaEN
-    neck: ClothingNeckDogtagMilitary # EN
+    dogtag: ClothingNeckDogtagMilitary # EN
 
 - type: startingGear
   id: MilitaryGearHead
@@ -227,7 +227,7 @@
     torso: ClothingTorsoTurtlenecksMilitary
     shoes: STClothingShoesBootsCombatFilled
     id: STOKSOPPdaEN
-    neck: ClothingNeckDogtagMilitaryCommander # EN
+    dogtag: ClothingNeckDogtagMilitaryCommander # EN
 
 - type: startingGear
   id: MilitarySpecGear

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/monolith.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/monolith.yml
@@ -105,7 +105,7 @@
   equipment:
     ears: STClothingChip
     id: MonolithPDA
-    neck: ClothingNeckDogtagMonolith # EN
+    dogtag: ClothingNeckDogtagMonolith # EN
     torso: ClothingTorsoTurtlenecksMonolithCamouflage
     legs: ClothingLegsJeansMonolithCamouflage
     shoes: STClothingShoesBootsCombat

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/neutral.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/neutral.yml
@@ -40,7 +40,7 @@
   id: NeutralGear
   equipment:
     id: StalkerPDA
-    neck: ClothingNeckDogtagNeutral # EN
+    dogtag: ClothingNeckDogtagNeutral # EN
     torso: ClothingTorsoNeutral
     legs: ClothingLegsJeansNeutral
     shoes: STClothingShoesBootsCombatFilled

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/pilgrims.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/pilgrims.yml
@@ -83,7 +83,7 @@
   id: PilgrimPostulantGear
   equipment:
     id: PilgrimPDA
-    cloak: ClothingNeckDogtagPilgrim
+    dogtag: ClothingNeckDogtagPilgrim
     shoes: ClothingShoesBootsLaceup
     legs: ClothingLegsJeansBlackCargo
     torso: ClothingTorsoTShirtColorBlack
@@ -98,7 +98,7 @@
     legs: ClothingLegsJeansBlackCargo
     pocket1: STPilgrimBible
     torso: ClothingTorsoTShirtColorBlack
-    pocket2: ClothingNeckDogtagPilgrim
+    dogtag: ClothingNeckDogtagPilgrim
 - type: stBand
   id: STPilgrimsBand
   name: Pilgrims

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/renegats.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/renegats.yml
@@ -70,7 +70,7 @@
   id: ReneGear
   equipment:
     id: BandPDA
-    neck: ClothingNeckDogtagRenegade # The Renegades are what happens when the Zone scrapes the absolute bottom of its radioactive boot and decides, “Yeah, this sludge can walk and shoot.” They’re not a faction so much as a disorganized parade of brain-dead scavengers who couldn’t survive five minutes without robbing someone smarter than them. No code, no spine, no competence — just a bunch of trigger-happy parasites mistaking cowardice for “freedom.” Even bandits look at Renegades and think, damn, at least we have standards. They infest ruins like mold, contribute nothing, betray everyone, and still somehow act surprised when the Zone chews them up and spits them out. If the Zone had a garbage disposal, Renegades would be the default setting.
+    dogtag: ClothingNeckDogtagRenegade # The Renegades are what happens when the Zone scrapes the absolute bottom of its radioactive boot and decides, “Yeah, this sludge can walk and shoot.” They’re not a faction so much as a disorganized parade of brain-dead scavengers who couldn’t survive five minutes without robbing someone smarter than them. No code, no spine, no competence — just a bunch of trigger-happy parasites mistaking cowardice for “freedom.” Even bandits look at Renegades and think, damn, at least we have standards. They infest ruins like mold, contribute nothing, betray everyone, and still somehow act surprised when the Zone chews them up and spits them out. If the Zone had a garbage disposal, Renegades would be the default setting.
 
 # Welcome back. Brigadier General Stalker, at your service. I see you want to be the leader of the renegades, huh? Well, you just can't have, working tests, because, YOU DON'T NEED THEM, OKAY?
 # I mean, you can, but you don't need them. You just need to be a badass and have the guts to lead the renegades. So, if you think you have what it takes, go ahead and take the job. But remember, it's not for the faint of heart. You will be leading a group of outlaws, and you will have to make tough decisions. But if you're up for the challenge, then welcome to the renegades.
@@ -86,7 +86,7 @@
   id: ReneGearHead
   equipment:
     id: BandPDA
-    neck: ClothingNeckDogtagRenegadeLeader
+    dogtag: ClothingNeckDogtagRenegadeLeader
 
   # AI generate me a yaml for a band of renegades in a stalker game. The band should have 11 members, with the leader being the "StalkerHeadRene" and the second in command being "StalkerRene". The band should be part of the "Stalker" faction and should have access to certain areas and items. The band should also have a hierarchy, with the leader being at the top and the second in command being below them. The band should also have a description and an icon. The band should be whitelisted and should have certain requirements for joining. The band should also have special abilities or perks that make them unique.
 

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/sci.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/sci.yml
@@ -158,7 +158,7 @@
   id: SciGear
   equipment:
     id: ScientistPDA
-    neck: ClothingNeckDogtagEco # EN
+    dogtag: ClothingNeckDogtagEco # EN
 
 - type: stBand
   id: STSciBand
@@ -195,7 +195,7 @@
   id: SciGear3
   equipment:
     id: ScientistPDA
-    neck: ClothingNeckDogtagEcoLeader # EN
+    dogtag: ClothingNeckDogtagEcoLeader # EN
     outerClothing: ClothingOuterCoatRD
     head: ClothingHeadBeretUN
     gloves: ClothingHandsGlovesNitrile

--- a/Resources/Prototypes/_Stalker/Roles/Jobs/stalkers.yml
+++ b/Resources/Prototypes/_Stalker/Roles/Jobs/stalkers.yml
@@ -132,7 +132,7 @@
   id: StalkerGear
   equipment:
     id: StalkerPDA
-    neck: ClothingNeckDogtagLoner # EN
+    dogtag: ClothingNeckDogtagLoner # EN
 
 - type: stBand
   id: STStalkerBand

--- a/Resources/Prototypes/_Stalker_EN/Roles/Jobs/rookie.yml
+++ b/Resources/Prototypes/_Stalker_EN/Roles/Jobs/rookie.yml
@@ -2,7 +2,7 @@
   id: StalkerRookieGear
   equipment:
     id: StalkerPDA
-    neck: ClothingNeckDogtagRookie
+    dogtag: ClothingNeckDogtagRookie
 
 - type: job
   id: StalkerRookie


### PR DESCRIPTION
## What I changed

Added a dedicated inventory slot for dog tags, separate from the neck slot. Previously dog tags occupied the neck slot, meaning players had to choose between wearing a dog tag and a neck accessory. Now dog tags have their own slot, allowing players to equip both at the same time.

## Changelog

author: @teecoding

- add: Dog tags now have their own dedicated equipment slot, freeing up the neck slot for other items

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
