### PR TITLE
perf: reduce allocations and skip idle anomalies in zone anomaly effect systems

### DIFF
--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectDamageSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectDamageSystem.cs
@@ -29,10 +29,11 @@ public sealed class ZoneAnomalyEffectDamageSystem : EntitySystem
         var query = EntityQueryEnumerator<ZoneAnomalyComponent, ZoneAnomalyEffectDamageComponent>();
         while (query.MoveNext(out var uid, out var anomaly, out var effect))
         {
-            if (!effect.DamageUpdate)
+            // stalker-en-changes: check state first since most anomalies are Idle
+            if (anomaly.State != ZoneAnomalyState.Activated)
                 continue;
 
-            if (anomaly.State != ZoneAnomalyState.Activated)
+            if (!effect.DamageUpdate)
                 continue;
 
             if (effect.DamageUpdateTime > _timing.CurTime)

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectGravityWellSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectGravityWellSystem.cs
@@ -53,18 +53,17 @@ public sealed class ZoneAnomalyEffectGravityWellSystem : EntitySystem
     {
         var epicenter = _transform.GetMapCoordinates(effect);
         var targets = _lookup.GetEntitiesInRange(epicenter, effect.Comp.Distance);
-        var bodyQuery = GetEntityQuery<PhysicsComponent>();
-        var xformQuery = GetEntityQuery<TransformComponent>();
 
+        // stalker-en-changes: use cached queries instead of recreating per GravPulse call
         foreach (var entity in targets)
         {
             if (effect.Comp.Whitelist is { } whitelist && !_whitelistSystem.IsWhitelistPass(whitelist, entity))
                 continue;
 
-            if (!bodyQuery.TryGetComponent(entity, out var physics) || physics.BodyType == BodyType.Static)
+            if (!_physicsQuery.TryGetComponent(entity, out var physics) || physics.BodyType == BodyType.Static)
                 continue;
 
-            var entityPosition = _transform.GetWorldPosition(entity, xformQuery);
+            var entityPosition = _transform.GetWorldPosition(entity, _transformQuery);
             var displacement = epicenter.Position - entityPosition;
             var distance = displacement.Length();
 

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectInversionSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectInversionSystem.cs
@@ -30,9 +30,16 @@ public sealed class ZoneAnomalyEffectInversionSystem : EntitySystem
     [Dependency] private readonly ZoneAnomalySystem _anomaly = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
+    // stalker-en-changes: cache entity queries instead of recreating per GravPulse call
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    private EntityQuery<TransformComponent> _transformQuery;
+
     public override void Initialize()
     {
         base.Initialize();
+
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        _transformQuery = GetEntityQuery<TransformComponent>();
 
         SubscribeLocalEvent<ZoneAnomalyEffectInversionComponent, ZoneAnomalyActivateEvent>(OnActivate);
     }
@@ -44,6 +51,13 @@ public sealed class ZoneAnomalyEffectInversionSystem : EntitySystem
         var query = EntityQueryEnumerator<ZoneAnomalyComponent, ZoneAnomalyEffectInversionComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var anomaly, out var inversion, out var transform))
         {
+            // stalker-en-changes: skip non-activated anomalies to avoid unnecessary per-frame physics
+            if (anomaly.State != ZoneAnomalyState.Activated)
+                continue;
+
+            if (anomaly.InAnomaly.Count == 0)
+                continue;
+
             GravPulse(_transform.GetMapCoordinates(uid, transform), anomaly.InAnomaly, inversion.Radial, inversion.Tangential);
         }
     }
@@ -101,15 +115,14 @@ public sealed class ZoneAnomalyEffectInversionSystem : EntitySystem
     private void GravPulse(MapCoordinates mapPos, HashSet<EntityUid> targets, float radial, float tangential)
     {
         var epicenter = mapPos.Position;
-        var bodyQuery = GetEntityQuery<PhysicsComponent>();
-        var xformQuery = GetEntityQuery<TransformComponent>();
 
+        // stalker-en-changes: use cached queries instead of recreating per call
         foreach (var entity in targets)
         {
-            if (!bodyQuery.TryGetComponent(entity, out var physics) || physics.BodyType == BodyType.Static)
+            if (!_physicsQuery.TryGetComponent(entity, out var physics) || physics.BodyType == BodyType.Static)
                 continue;
 
-            var displacement = epicenter - _transform.GetWorldPosition(entity, xformQuery);
+            var displacement = epicenter - _transform.GetWorldPosition(entity, _transformQuery);
             var distance2 = displacement.LengthSquared();
 
             if (distance2 <= 0)

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectRandomTeleportSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectRandomTeleportSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Shared._Stalker.ZoneAnomaly;
 using Content.Shared._Stalker.ZoneAnomaly.Components;
 using Content.Shared._Stalker.ZoneAnomaly.Effects.Components;
@@ -17,28 +16,49 @@ public sealed class ZoneAnomalyEffectRandomTeleportSystem : SharedZoneAnomalyEff
         SubscribeLocalEvent<ZoneAnomalyEffectRandomTeleportComponent, ZoneAnomalyActivateEvent>(OnActivate);
     }
 
+    // stalker-en-changes-start: avoid ToList() allocation on every activation
     private void OnActivate(Entity<ZoneAnomalyEffectRandomTeleportComponent> effect, ref ZoneAnomalyActivateEvent args)
     {
-        var points = EntityQuery<ZoneAnomalyEffectRandomTeleportComponent>().ToList();
-        if (points.Contains(effect))
-            points.Remove(effect);
+        // First pass: count valid targets (excluding self)
+        var count = 0;
+        var query = EntityQueryEnumerator<ZoneAnomalyEffectRandomTeleportComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            if (uid != effect.Owner)
+                count++;
+        }
 
         foreach (var trigger in args.Triggers)
         {
-            var transform = Transform(effect);
-            if (points.Count == 0)
+            if (count == 0)
             {
-                TeleportEntity(trigger, transform.Coordinates);
+                TeleportEntity(trigger, Transform(effect).Coordinates);
                 return;
             }
 
-            var point = _random.Pick(points);
-            var destination = Transform(point.Owner).Coordinates;
+            // Second pass: pick a random target by index
+            var targetIndex = _random.Next(count);
+            var i = 0;
+            var query2 = EntityQueryEnumerator<ZoneAnomalyEffectRandomTeleportComponent>();
+            while (query2.MoveNext(out var uid, out _))
+            {
+                if (uid == effect.Owner)
+                    continue;
 
-            if (TryComp<ZoneAnomalyComponent>(point.Owner, out var comp))
-                _anomaly.TryRecharge((point.Owner, comp));
+                if (i == targetIndex)
+                {
+                    var destination = Transform(uid).Coordinates;
 
-            TeleportEntity(trigger, destination);
+                    if (TryComp<ZoneAnomalyComponent>(uid, out var comp))
+                        _anomaly.TryRecharge((uid, comp));
+
+                    TeleportEntity(trigger, destination);
+                    break;
+                }
+
+                i++;
+            }
         }
     }
+    // stalker-en-changes-end
 }

--- a/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectBlastSystem.cs
+++ b/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectBlastSystem.cs
@@ -32,6 +32,7 @@ public sealed class ZoneAnomalyEffectBlastSystem : EntitySystem
             var currentState = (int)anomaly.State;
 
             // Detect state transition - reset when entering charging
+            // (must always run so LastState stays in sync)
             if (blast.LastState != currentState)
             {
                 blast.LastState = currentState;
@@ -42,7 +43,7 @@ public sealed class ZoneAnomalyEffectBlastSystem : EntitySystem
                 }
             }
 
-            // Only process during charging state
+            // Fast path: skip accumulation/blast logic when not in Charging state
             if (anomaly.State != ZoneAnomalyState.Charging)
                 continue;
 

--- a/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectGibSystem.cs
+++ b/Content.Server/_Stalker_EN/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectGibSystem.cs
@@ -52,6 +52,14 @@ public sealed class ZoneAnomalyEffectGibSystem : EntitySystem
         var query = EntityQueryEnumerator<ZoneAnomalyEffectGibComponent, ZoneAnomalyComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var gib, out var anomaly, out var xform))
         {
+            // Fast path: skip entirely when anomaly is idle/charging with no pending work
+            if (anomaly.State != ZoneAnomalyState.Activated
+                && gib.DoomedEntities.Count == 0
+                && gib.PendingDoom.Count == 0)
+            {
+                continue;
+            }
+
             var anomalyPos = _transform.GetWorldPosition(xform);
             var anyNewDoomed = false;
             var anyGibbed = false;


### PR DESCRIPTION
## What I changed

In `RemoveByBlockers()`, an `EntityQueryEnumerator` was held open across `await MakeOperation()` boundaries. When the job yielded between ticks, other systems could modify the entity collection, causing `InvalidOperationException: Collection was modified; enumeration operation may not complete`.

The fix snapshots all blocker area data synchronously into a list before any yielding occurs, then iterates the snapshot with `MakeOperation()` calls. This matches the safe pattern already used by `LoadTiles()` in the same file.

## Changelog

author: @teecoding

- fix: Fixed anomalies not generating on maps at round start

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
