### PR TITLE
fix: hide door access description from non-admin players

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Content.Shared.Access.Components;
+using Content.Shared.Administration.Managers;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
@@ -25,6 +26,7 @@ namespace Content.Shared.Access.Systems;
 
 public sealed class AccessReaderSystem : EntitySystem
 {
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
@@ -54,6 +56,10 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnExamined(Entity<AccessReaderComponent> ent, ref ExaminedEvent args)
     {
+        // stalker-changes: only show access descriptions to admins
+        if (!_admin.IsAdmin(args.Examiner))
+            return;
+
         if (!GetMainAccessReader(ent, out var mainAccessReader))
             return;
 


### PR DESCRIPTION
## What I changed

Door access descriptions are now hidden from regular players when examining doors. Only admins can see which access a door requires.

## Changelog

author: @teecoding

- tweak: Door access requirements are no longer visible to regular players on examine

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
