### PR TITLE
fix: make clothing-based identity hiding reliable

### DIFF
--- a/Content.Server/Clothing/ClothingSystem.cs
+++ b/Content.Server/Clothing/ClothingSystem.cs
@@ -1,77 +1,7 @@
-using Content.Server.Humanoid;
-using Content.Server.Preferences.Managers;
-using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
-using Content.Shared.IdentityManagement.Components;
-using Content.Shared.Inventory.Events;
-using Content.Shared.Mind;
-using Content.Shared.Mind.Components;
-using Content.Shared.Preferences;
-using Robust.Shared.Enums;
-using Robust.Shared.Player;
 
 namespace Content.Server.Clothing;
 
 public sealed class ServerClothingSystem : ClothingSystem
 {
-    // stalker-changes-starts
-
-    [Dependency] private readonly MetaDataSystem _metaSystem = default!;
-    [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
-    [Dependency] private readonly IServerPreferencesManager _prefsManager = default!;
-
-    protected override void OnGotEquipped(EntityUid uid, ClothingComponent component, GotEquippedEvent args)
-    {
-        base.OnGotEquipped(uid, component, args);
-        bool isIdentityBlocker = HasComp<IdentityBlockerComponent>(uid);
-        if (args.Slot == "mask" && isIdentityBlocker)
-            ChangeName(args.Equipee, true);
-    }
-
-    protected override void OnGotUnequipped(EntityUid uid, ClothingComponent component, GotUnequippedEvent args)
-    {
-        base.OnGotUnequipped(uid, component, args);
-        bool isIdentityBlocker = HasComp<IdentityBlockerComponent>(uid);
-        if (args.Slot == "mask" && isIdentityBlocker)
-            ChangeName(args.Equipee, false);
-    }
-
-    private void ChangeName(EntityUid entity, bool isHidden)
-    {
-        if (!TryComp<ActorComponent>(entity, out var actor))
-            return;
-
-        HumanoidCharacterProfile profile;
-
-        if (_prefsManager.TryGetCachedPreferences(actor.PlayerSession.UserId, out var preferences))
-        {
-            profile = (HumanoidCharacterProfile)preferences.GetProfile(preferences.SelectedCharacterIndex);
-        }
-        else
-        {
-            profile = HumanoidCharacterProfile.Random();
-        }
-
-        int num = profile.Name.GetHashCode();
-        byte[] bytes = BitConverter.GetBytes(num);
-        string base64String = Convert.ToBase64String(bytes);
-        string code = base64String.Substring(0, 3);
-
-        if (!isHidden)
-        {
-            _metaSystem.SetEntityName(entity, profile.Name);
-            return;
-        }
-
-        var ageString = _humanoidSystem.GetAgeRepresentation(profile.Species, profile.Age);
-        var genderString = profile.Gender switch
-        {
-            Gender.Female => Loc.GetString("identity-gender-feminine"),
-            Gender.Male => Loc.GetString("identity-gender-masculine"),
-            Gender.Epicene or Gender.Neuter or _ => Loc.GetString("identity-gender-person")
-        };
-
-        _metaSystem.SetEntityName(entity, $"{ageString} {genderString}");
-    }
-    // stalker-changes-ends
 }

--- a/Content.Shared/IdentityManagement/IdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/IdentitySystem.cs
@@ -197,7 +197,12 @@ public sealed class IdentitySystem : EntitySystem
         var ev = new SeeIdentityAttemptEvent();
 
         RaiseLocalEvent(target, ev);
-        return representation.ToStringKnown(!ev.Cancelled);
+        // stalker-en-changes-start
+        // When identity is fully blocked, always use unknown representation.
+        // Base SS14 falls back to ID card name via PresumedName, but in Stalker full face
+        // coverage should completely hide identity regardless of equipped ID.
+        return ev.Cancelled ? representation.ToStringUnknown() : representation.ToStringKnown(true);
+        // stalker-en-changes-end
     }
 
     /// <summary>

--- a/Content.Shared/_Stalker_EN/Clothing/STFoldableIdentityBlockerSystem.cs
+++ b/Content.Shared/_Stalker_EN/Clothing/STFoldableIdentityBlockerSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Foldable;
+using Content.Shared.IdentityManagement;
+using Content.Shared.IdentityManagement.Components;
+using Content.Shared.Inventory;
+
+namespace Content.Shared._Stalker_EN.Clothing;
+
+/// <summary>
+/// Toggles <see cref="IdentityBlockerComponent.Enabled"/> when a foldable clothing item
+/// is folded or unfolded. This fixes balaclavas which start with identity blocking disabled
+/// (since they're worn on HEAD when folded) but need it enabled when unfolded to the MASK slot.
+/// </summary>
+public sealed class STFoldableIdentityBlockerSystem : EntitySystem
+{
+    [Dependency] private readonly IdentitySystem _identity = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IdentityBlockerComponent, FoldedEvent>(OnFolded);
+    }
+
+    private void OnFolded(Entity<IdentityBlockerComponent> ent, ref FoldedEvent args)
+    {
+        // When folded (e.g., balaclava on HEAD) → disable identity blocking.
+        // When unfolded (e.g., balaclava on MASK) → enable identity blocking.
+        ent.Comp.Enabled = !args.IsFolded;
+        Dirty(ent);
+
+        // If the item is currently equipped, update the wearer's identity.
+        if (_inventory.TryGetContainingSlot(ent.Owner, out _))
+        {
+            var wearer = Transform(ent).ParentUid;
+            _identity.QueueIdentityUpdate(wearer);
+        }
+    }
+}

--- a/Content.Shared/_Stalker_EN/IdentityManagement/STIdentityVoiceSystem.cs
+++ b/Content.Shared/_Stalker_EN/IdentityManagement/STIdentityVoiceSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Chat;
+using Content.Shared.IdentityManagement;
+using Content.Shared.IdentityManagement.Components;
+
+namespace Content.Shared._Stalker_EN.IdentityManagement;
+
+/// <summary>
+/// Bridges the identity system into chat and radio by replacing the raw MetaData voice name
+/// with the identity-aware name from <see cref="Identity.Name"/>. This ensures that when a
+/// player's identity is blocked (e.g., by a mask or helmet with <see cref="IdentityBlockerComponent"/>),
+/// their hidden identity is also used in chat messages and radio transmissions.
+/// </summary>
+public sealed class STIdentityVoiceSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<IdentityComponent, TransformSpeakerNameEvent>(OnTransformSpeakerName);
+    }
+
+    private void OnTransformSpeakerName(Entity<IdentityComponent> ent, ref TransformSpeakerNameEvent args)
+    {
+        args.VoiceName = Identity.Name(ent, EntityManager);
+    }
+}

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Mask/balaklavas.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Mask/balaklavas.yml
@@ -18,7 +18,7 @@
     - FacialHair
   - type: IdentityBlocker
     enabled: false
-    coverage: MOUTH
+    coverage: FULL # stalker-en-changes
   - type: Sprite
     layers:
     - state: icon_head

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorExoskeleton.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorExoskeleton.yml
@@ -62,6 +62,8 @@
     reflects:
     - NonEnergy
     soundOnReflect: /Audio/_Stalker/Effects/sear.ogg
+  - type: IngestionBlocker # stalker-en-changes
+  - type: IdentityBlocker # stalker-en-changes
   - type: HideLayerClothing
     slots:
     - Hair
@@ -125,6 +127,8 @@
       sprite: _Stalker/Objects/Clothing/outerClothing/zavet_ekzo/helmet.rsi
     - type: Clothing
       sprite: _Stalker/Objects/Clothing/outerClothing/zavet_ekzo/helmet.rsi
+    - type: IngestionBlocker # stalker-en-changes
+    - type: IdentityBlocker # stalker-en-changes
 
 # Project
 


### PR DESCRIPTION
## What I changed

Removed the broken `ChangeName` hack from `ServerClothingSystem` that was fighting with the base SS14 `IdentitySystem`. Replaced it with two small systems that properly integrate with existing infrastructure:

- `STIdentityVoiceSystem`: Bridges the identity system into chat/radio so masked players show as "middle-aged man" etc. instead of their real name when speaking.
- `STFoldableIdentityBlockerSystem`: Toggles `IdentityBlocker.Enabled` when balaclavas are folded/unfolded so they actually hide identity when worn as a mask.

Also fixed `IdentitySystem.GetIdentityName` to use `ToStringUnknown()` when face is fully covered, instead of leaking the player's real name from their ID card.

Added missing `IdentityBlocker` + `IngestionBlocker` to the base exoskeleton helmet and Covenant exoskeleton helmet. Changed balaclava coverage from `MOUTH` to `FULL`.

## Changelog

author: @teecoding

- fix: Masks, gas masks, helmets and balaclavas now properly hide your name when examining and in chat/radio
- fix: Balaclavas now correctly hide identity when unfolded to the mask slot
- fix: Wearing a full face cover no longer leaks your real name through your ID card
- add: Base exoskeleton helmet and Covenant exoskeleton helmet now hide your identity

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
