### PR TITLE
fix: show sender name instead of owner name in PDA DMs

### DIFF
--- a/Content.Server/_Stalker/PdaMessenger/PdaMessengerSystem.cs
+++ b/Content.Server/_Stalker/PdaMessenger/PdaMessengerSystem.cs
@@ -186,7 +186,18 @@ public sealed class PdaMessengerSystem : EntitySystem
                 continue;
             }
 
-            chats.Add(chat);
+            // stalker-en-changes: For DM chats, display the other person's name
+            if (chat.Receiver is not null && chat.Receiver == ownerName)
+            {
+                var displayChat = new PdaChat(chat.Sender ?? chat.Name, chat.Receiver, chat.Sender);
+                foreach (var msg in chat.Messages)
+                    displayChat.Messages.Add(msg);
+                chats.Add(displayChat);
+            }
+            else
+            {
+                chats.Add(chat);
+            }
         }
 
         var state = new MessengerUiState(chats);


### PR DESCRIPTION
## What I changed
Fixed PDA direct messages showing the recipient's own name instead of the sender's name in the chat list.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/507

## Changelog
author: @teecoding

- fix: PDA DMs now correctly show the sender's name instead of your own name

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
