### PR TITLE
fix: use transformed speaker name for handheld radio on StalkerInternal channel

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -187,6 +187,8 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
         if (args.Channel.ID == "StalkerInternal" && TryComp<RadioStalkerComponent>(uid, out var receiverStalkerComp) && receiverStalkerComp.CurrentFrequency != null)
         {
             // Frequencies matched in OnStalkerReceiveAttempt.
+            var nameEv = new TransformSpeakerNameEvent(args.MessageSource, MetaData(args.MessageSource).EntityName);
+            RaiseLocalEvent(args.MessageSource, nameEv);
             var speechVerb = _chat.GetSpeechVerb(args.MessageSource, args.Message);
             var wrappedMessage = Loc.GetString("chat-radio-message-wrap",
                 ("channel", string.Empty), // receiverStalkerComp.CurrentFrequency
@@ -194,7 +196,7 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
                 ("fontSize", speechVerb.FontSize),
                 ("verb", string.Empty), // Loc.GetString(speechVerb.ID)
                 ("color", args.Channel.Color),
-                ("name", Name(args.MessageSource)),
+                ("name", nameEv.VoiceName),
                 ("message", args.Message));
 
             _chat.TrySendInGameICMessage(uid, wrappedMessage, InGameICChatType.Whisper, ChatTransmitRange.GhostRangeLimit, checkRadioPrefix: false);


### PR DESCRIPTION
## What I changed

Fixed handheld radios on the StalkerInternal channel showing the sender's real name instead of their disguised identity (e.g. "old man") when the sender is wearing a mask or helmet.

## Changelog

author: @teecoding

- fix: Handheld radios now correctly show disguised names instead of real names when the sender is wearing identity-blocking gear

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
