### PR TITLE
fix: localize hardcoded Russian strings in ban webhook embed

### DIFF
--- a/Content.Server/_Stalker/Discord/BanWebhook.cs
+++ b/Content.Server/_Stalker/Discord/BanWebhook.cs
@@ -73,7 +73,7 @@ public sealed class BanWebhook
         {
             var expirationDate = DateTime.UtcNow.Add(TimeSpan.FromMinutes((double) minutes));
             banType = Loc.GetString("ban-embed-temp", ("time", minutes));
-            expires = $"**Истекает:** {expirationDate}\n";
+            expires = Loc.GetString("ban-embed-expires", ("time", expirationDate)) + "\n";
             color = 0xFF9900;
         }
 
@@ -92,13 +92,13 @@ public sealed class BanWebhook
                         IconUrl = string.IsNullOrWhiteSpace(_footerIconUrl) ? null : _footerIconUrl
                     },
                     Description =
-                        $"**Нарушитель**: {user.Split(" ")[0]}\n" +
-                        $"**Администратор:** {admin}\n" +
-                        $"\n" +
-                        $"**Выдан:** {timeNow}\n" +
+                        Loc.GetString("ban-embed-offender", ("user", user.Split(" ")[0])) + "\n" +
+                        Loc.GetString("ban-embed-admin", ("admin", admin)) + "\n" +
+                        "\n" +
+                        Loc.GetString("ban-embed-issued", ("time", timeNow)) + "\n" +
                         expires +
-                        $"\n" +
-                        $"**Причина:** {reason}"
+                        "\n" +
+                        Loc.GetString("ban-embed-reason", ("reason", reason))
                 }
             },
         };

--- a/Resources/Locale/en-US/_stalker/discord/ban-embed.ftl
+++ b/Resources/Locale/en-US/_stalker/discord/ban-embed.ftl
@@ -3,3 +3,8 @@
 ban-embed-footer = Severity: { $severity }
 ban-embed-perm = Permanent ban
 ban-embed-temp = Temporary ban for { $time } minutes
+ban-embed-offender = **Offender**: { $user }
+ban-embed-admin = **Administrator:** { $admin }
+ban-embed-issued = **Issued:** { $time }
+ban-embed-expires = **Expires:** { $time }
+ban-embed-reason = **Reason:** { $reason }

--- a/Resources/Locale/ru-RU/_stalker/discord/ban-embed.ftl
+++ b/Resources/Locale/ru-RU/_stalker/discord/ban-embed.ftl
@@ -3,3 +3,8 @@
 ban-embed-footer = Тяжесть: { $severity }
 ban-embed-perm = Перманентный бан
 ban-embed-temp = Временный бан на { $time } минут
+ban-embed-offender = **Нарушитель**: { $user }
+ban-embed-admin = **Администратор:** { $admin }
+ban-embed-issued = **Выдан:** { $time }
+ban-embed-expires = **Истекает:** { $time }
+ban-embed-reason = **Причина:** { $reason }


### PR DESCRIPTION
## What changed
  Replaced hardcoded Russian strings in the ban Discord webhook embed with localized English text. Added locale keys
  for offender, administrator, issued, expires, and reason fields.                                                   

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the
  [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are
  under an open license
