### PR TITLE
docs(wiki): add codebase organization, trim duplication, fix sidebar links

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,45 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/wiki/**'
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki-repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync wiki files
+        run: |
+          # Remove existing wiki content (except .git)
+          find wiki-repo -maxdepth 1 -not -name '.git' -not -name 'wiki-repo' -not -path wiki-repo -delete
+          # Copy all markdown files from docs/wiki to wiki repo
+          cp docs/wiki/*.md wiki-repo/
+
+      - name: Push to wiki
+        run: |
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes to commit"
+          else
+            git commit -m "Sync wiki from docs/wiki ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+            git push
+          fi

--- a/docs/wiki/Codebase-Architecture.md
+++ b/docs/wiki/Codebase-Architecture.md
@@ -1,0 +1,108 @@
+# Codebase Architecture
+
+> Project structure, the three-layer convention, and where things live.
+
+[Back to Home](Home)
+
+## The Three-Layer Convention
+
+| Directory | Owner | Rule |
+|-----------|-------|------|
+| Base directories (e.g., `Content.Server/Station/`) | Upstream SS14 | Do not modify unless absolutely necessary |
+| `_Stalker/` | Upstream Stalker-14 (closed Russian fork) | Do not modify unless absolutely necessary |
+| `_Stalker_EN/` | **This fork** | **All new code goes here** |
+
+### Why This Exists
+
+Stalker-14-EN sits at the end of a three-project inheritance chain:
+
+```
+Space Station 14 (upstream engine + content)
+  +-- Stalker-14 (closed Russian fork)
+       +-- stalker-14-EN (English localization + new features)
+```
+
+Upstream Stalker-14 changes get merged periodically. The `_Stalker_EN/` convention creates a clean boundary: upstream merges only touch base and `_Stalker/` files, while EN work only touches `_Stalker_EN/` files. Conflicts become rare and isolated.
+
+> **Warning**: When you *must* modify a file outside `_Stalker_EN/`, mark changes with `// stalker-en` (single line) or `// stalker-en-start` / `// stalker-en-end` (multi-line blocks). Do **not** use `// stalker-changes`, which is the upstream Stalker marker.
+
+## Directory Structure
+
+```
+stalker-14-EN/
++-- Content.Client/                  # Client-side code (UI, rendering, visual-only systems)
+|   +-- _Stalker/                    # Upstream Stalker client code (DO NOT MODIFY)
+|   +-- _Stalker_EN/                 # EN-specific client code
+|
++-- Content.Server/                  # Server-side code (authoritative game logic)
+|   +-- _Stalker/                    # Upstream Stalker server code (DO NOT MODIFY)
+|   +-- _Stalker_EN/                 # EN-specific server code
+|
++-- Content.Shared/                  # Shared code (runs on BOTH client and server)
+|   +-- _Stalker/                    # Upstream Stalker shared code (DO NOT MODIFY)
+|   +-- _Stalker_EN/                 # EN-specific shared code
+|
++-- Content.Server.Database/         # EF Core database models and migrations
++-- Content.Shared.Database/         # Database enums and types shared with other projects
++-- Content.IntegrationTests/        # Integration tests (NUnit)
++-- Content.Tests/                   # Unit tests (NUnit)
+|
++-- Resources/
+|   +-- Prototypes/
+|   |   +-- _Stalker/               # Upstream YAML prototypes
+|   |   +-- _Stalker_EN/            # EN-specific YAML prototypes
+|   +-- Locale/
+|   |   +-- en-US/_Stalker_EN/      # EN localization strings (.ftl files)
+|   |   +-- ru-RU/                  # Russian locale (upstream)
+|   +-- Textures/_Stalker_EN/       # EN-specific sprites
+|   +-- Audio/_Stalker_EN/          # EN-specific audio assets
+|   +-- Maps/                       # Map files
+|
++-- Corvax/                          # Corvax interface projects (upstream dependency)
++-- RobustToolbox/                   # Engine submodule (NEVER MODIFY)
++-- Stalker14.sln                    # Solution file
+```
+
+## Client / Server / Shared Split
+
+**Shared** (`Content.Shared/`): Compiled into both client and server. Components, events, shared systems (prediction), data types, enums.
+
+**Server** (`Content.Server/`): Server-only. Authoritative game logic, anti-cheat, database access, hidden AI decisions.
+
+**Client** (`Content.Client/`): Client-only. UI (always XAML), visual effects, input handling, prediction overrides.
+
+### How to Decide
+
+1. **Both sides need this type or logic?** Shared.
+2. **Determines what "really happened"?** Server.
+3. **Purely visual, UI, or input?** Client.
+4. **Unsure?** Default to Server.
+
+> **Tip**: Components almost always go in Shared, even if the system is server-only. The client needs the component definition to deserialize entity state.
+
+## CCVars: Runtime Configuration
+
+CCVars can be changed at runtime through the server console or config files without recompiling.
+
+EN-specific CCVars are defined in `Content.Shared/_Stalker_EN/CCVar/` as partial classes on `STCCVars`:
+
+| File | Feature Area |
+|------|-------------|
+| `STCCVars.Emission.cs` | Emission system visuals and raycasting |
+| `STCCVars.FactionRelations.cs` | Discord webhook, cooldown, proposal expiration |
+| `STCCVars.LateJoin.cs` | Late join announcement toggle |
+| `STCCVars.Loadout.cs` | Rate limiting |
+| `STCCVars.Messenger.cs` | Discord webhook, max message length |
+
+All EN CVars use the `stalkeren.*` prefix. Upstream Stalker uses `stalker.*`. Do not add new variables to `_Stalker/CCCCVars/`; use the `STCCVars` partial class in `_Stalker_EN/`.
+
+To add a new CCVar: create `STCCVars.YourFeature.cs` in `Content.Shared/_Stalker_EN/CCVar/`. Naming: `stalkeren.feature.variable_name`. Flags: `CVar.SERVERONLY`, `CVar.CLIENTONLY`, `CVar.REPLICATED`, `CVar.CONFIDENTIAL`.
+
+## Related Pages
+
+- [Home](Home)
+- [Contributing Guide](Contributing-Guide): coding conventions, ECS rules, naming, style, and PR workflow
+- [Robust Toolbox ECS](https://docs.spacestation14.com/en/robust-toolbox/ecs.html): engine ECS documentation
+- [SS14 Codebase Organization](https://docs.spacestation14.com/en/general-development/codebase-info/codebase-organization.html)
+- [SS14 Conventions](https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html)
+- [SS14 PR Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)

--- a/docs/wiki/Contributing-Guide.md
+++ b/docs/wiki/Contributing-Guide.md
@@ -1,0 +1,381 @@
+# Contributing Guide
+
+> Coding conventions, code placement rules, and contribution workflow for Stalker-14-EN.
+
+This page is the reference for how to write code that fits into the Stalker-14-EN codebase. For project structure rationale and the Shared/Server/Client split, see [Codebase Architecture](Codebase-Architecture).
+
+## Where to Put New Code
+
+### The Three-Layer Rule
+
+```
+Base SS14 code           -->  Do not modify (unless absolutely necessary)
+_Stalker/ directories    -->  Upstream Stalker code. Do not modify (unless absolutely necessary)
+_Stalker_EN/ directories -->  ALL new EN-fork code goes here
+```
+
+Every new feature, bugfix, or extension specific to the EN fork **must** live under a `_Stalker_EN/` directory. This is non-negotiable.
+
+### Directory Map
+
+| What you are writing | Where it goes |
+|---|---|
+| Components, events, enums, shared systems | `Content.Shared/_Stalker_EN/YourFeature/` |
+| Server-only game logic, authoritative systems | `Content.Server/_Stalker_EN/YourFeature/` |
+| UI code, visuals, client-only systems | `Content.Client/_Stalker_EN/YourFeature/` |
+| YAML entity/prototype definitions | `Resources/Prototypes/_Stalker_EN/YourFeature/` |
+| Localization strings | `Resources/Locale/en-US/_Stalker_EN/yourfeature.ftl` |
+
+### Prototype Path Mirroring
+
+When overriding or extending upstream prototypes, **mirror the upstream folder structure** inside `_Stalker_EN/`. This keeps the relationship between original and overridden prototypes obvious and makes it easy to trace changes back to the source.
+
+```
+Upstream prototype at:
+  Resources/Prototypes/_Stalker/Entities/Mobs/mutants.yml
+
+Override goes to:
+  Resources/Prototypes/_Stalker_EN/Entities/Mobs/mutants.yml
+```
+
+Do **not** invent a new folder hierarchy for overridden prototypes. The path under `_Stalker_EN/` should match the path under `_Stalker/` (or the base `Prototypes/` directory if overriding base SS14 prototypes).
+
+### When You Must Touch Upstream Code
+
+1. **Minimize the diff**: smallest possible change
+2. **Mark it clearly** with the correct comment marker (see below)
+3. **Ask before proceeding**: modifications to upstream code should be reviewed first
+
+**Comment markers for EN-fork changes to upstream files:**
+
+```csharp
+// Single line change:
+var result = DoSomething(); // stalker-en
+
+// Multi-line block:
+// stalker-en-start
+var custom = NewLogic();
+ApplyCustom(custom);
+// stalker-en-end
+```
+
+> **Warning**: Upstream Stalker uses `// stalker-changes` for its own modifications. Do **not** use that marker for EN-fork changes.
+
+## Naming Conventions
+
+### C# Identifiers
+
+| Kind | Convention | Example |
+|---|---|---|
+| Classes, structs, enums | `PascalCase` | `STSoftCritComponent` |
+| Interfaces | `IPascalCase` | `IRadarTargetSource` |
+| Methods, properties | `PascalCase` | `OnMapInit`, `CrawlSpeedModifier` |
+| Private fields | `_camelCase` | `_random`, `_sawmill` |
+| Parameters, locals | `camelCase` | `frameTime`, `uid` |
+| Constants | `PascalCase` | `DefaultCrawlSpeed` |
+| Stalker-specific types | `ST` prefix | `STWeaponSystem`, `STMobVariantComponent` |
+
+> **Note**: The `ST` prefix is **recommended** for all Stalker-specific types. It prevents name collisions with base SS14 types and makes grep-based navigation reliable.
+
+### Localization IDs
+
+Always `kebab-case`, never capitalized. Prefix with `st-` to avoid clashing with base SS14 locale keys. All player-facing strings must use `Loc.GetString()`.
+
+```
+st-trophy-examine-quality = [color={$color}]{$quality}[/color]
+st-messenger-channel-general = General
+st-soft-crit-crawl-popup = You begin crawling...
+```
+
+### YAML Identifiers
+
+| Kind | Convention | Example |
+|---|---|---|
+| Prototype IDs | `PascalCase` | `STMessengerCartridge`, `STGeneral` |
+| Component type names | `PascalCase` | `STMessenger`, `STSoftCritEnabled` |
+| Data fields | `camelCase` | `crawlSpeedModifier`, `sortOrder` |
+
+## ECS Rules
+
+These are architectural requirements of the Robust Toolbox engine, not style preferences.
+
+### Components Are Pure Data
+
+No logic, no methods that compute values, no property setters with side effects. All data must be public.
+
+```csharp
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STSoftCritComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float CrawlSpeedModifier = 0.3f;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 HardCritThreshold;
+}
+```
+
+### All Logic Lives in Systems
+
+EntitySystems subscribe to events and operate on entities through their components. Prefer `EntitySystem` proxy methods (`Name(uid)`, `Transform(uid)`) over direct `EntityManager` access.
+
+```csharp
+public sealed class STMobVariantSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<STMobVariantConfigComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, STMobVariantConfigComponent config, MapInitEvent args)
+    {
+        // All logic here, never in the component
+    }
+}
+```
+
+### Public API Signatures
+
+Use `Entity<T?>` for entity/component parameters and call `Resolve()` immediately:
+
+```csharp
+public void SetCount(Entity<StackComponent?> stack, int count)
+{
+    if (!Resolve(stack, ref stack.Comp))
+        return;
+
+    stack.Comp.Count = count;
+    Dirty(stack);
+}
+```
+
+### Dirty() and DirtyField()
+
+When you modify a networked component's state, you must mark it dirty. Forgetting this is the most common "works on server but clients see stale data" bug.
+
+**`Dirty()`**: Use when most/all fields changed.
+
+```csharp
+marker.Quality = variant.Quality;
+marker.Applied = true;
+Dirty(uid, marker);
+```
+
+**`DirtyField()`**: Use for components with 3+ independently changing networked fields. Requires `AutoGenerateComponentState(fieldDeltas: true)` on the component.
+
+```csharp
+comp.Health = newValue;
+DirtyField(uid, comp, nameof(STExampleComponent.Health));
+```
+
+> **Warning**: Server-only components (like `DestructibleComponent`) do not need dirty calls. If unsure whether a component is networked, call it anyway; it is a no-op on non-networked components.
+
+### Events
+
+Events must be **structs** with `[ByRefEvent]`, raised by reference. Name with `Event` suffix; handlers named `OnXEvent`.
+
+```csharp
+[ByRefEvent]
+public record struct STSoftCritSpeechEvent(EntityUid Source)
+{
+    public bool Override = false;
+}
+```
+
+Do not raise events directly for actions. Wrap them in entity system methods:
+
+```csharp
+// CORRECT: System method wraps the event
+public void ApplyDamage(EntityUid target, DamageSpecifier damage)
+{
+    var ev = new STDamageAppliedEvent(target, damage);
+    RaiseLocalEvent(target, ref ev);
+}
+```
+
+Use EventBus for simulation code, not C# events. C# events are only for out-of-simulation code (UI). Always unsubscribe from C# events to prevent leaks.
+
+### Optional Entities
+
+Use nullable `EntityUid?` to represent absence. Never use `EntityUid.Invalid`.
+
+```csharp
+// CORRECT
+public EntityUid? Target;
+
+// WRONG
+public EntityUid Target = EntityUid.Invalid;
+```
+
+### Additional ECS Rules
+
+- **Mark all classes** as `sealed`, `abstract`, `static`, or `[Virtual]`.
+- **No async in simulation code**: use events and `DoAfter` instead.
+- **No extension methods** on `EntityUid`, components, or systems.
+- **Use `[DataField]`** for YAML-configurable component fields.
+- **Use `TimeSpan`** instead of `float` for time durations. Apply `[AutoPausedField]` for absolute time points. Apply `[AutoGenerateComponentPause]` to the component class.
+- **Use `ProtoId<T>`** instead of caching prototype references.
+- **Use `SoundSpecifier`** (prefer `SoundCollectionSpecifier`) for sound fields.
+- **Use `SpriteSpecifier`** for sprite/texture fields.
+
+## The Reusability Mandate
+
+Before writing new code, search the existing codebase thoroughly.
+
+### Search Order
+
+1. `Content.Shared/_Stalker_EN/` and `Content.Server/_Stalker_EN/`: has the EN fork already solved this?
+2. `Content.Shared/_Stalker/` and `Content.Server/_Stalker/`: does upstream Stalker have it?
+3. `Content.Shared/` and `Content.Server/`: does base SS14 provide this?
+
+### Decision Tree
+
+```
+Can an existing system do exactly what I need?
+  YES --> Use it directly.
+  NO  --> Can it be extended?
+            YES --> Extend it (prefer composition over modification).
+            NO  --> Create new code in _Stalker_EN/.
+```
+
+Duplicating existing functionality is unacceptable.
+
+## Code Style
+
+### Formatting
+
+- **4-space indentation** (spaces, not tabs)
+- **120-character max line length**
+- **Allman-style braces** (opening brace on its own line)
+- **File-scoped namespaces**
+- **Fields and auto-properties before methods**
+- **Trailing commas** in multiline initializer lists
+- Use `var` when the type is apparent
+- No `this.` qualification
+- Use C# keywords over BCL types (`int` not `Int32`)
+
+```csharp
+namespace Content.Server._Stalker_EN.MobVariant;
+
+public sealed class STMobVariantSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _sawmill = Logger.GetSawmill("st.mob.variant");
+        SubscribeLocalEvent<STMobVariantConfigComponent, MapInitEvent>(OnMapInit);
+    }
+}
+```
+
+### Documentation
+
+Use XML documentation comments on public classes, methods, properties, and non-obvious fields. Comments should explain **why**, not restate **what**.
+
+```csharp
+/// <summary>
+/// Runtime component added/removed when an entity is in the soft crit sub-phase.
+/// Its presence means the entity can crawl slowly and whisper but cannot stand,
+/// use items, or speak normally.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class STSoftCritComponent : Component
+```
+
+### YAML Prototype Style
+
+- Separate prototypes with one blank line
+- No blank lines between components within a prototype
+- Field order: `type` -> `abstract` -> `parent` -> `id` -> `categories` -> `name` -> `suffix` -> `description` -> `components`
+- Engine components before content components
+- `name:` and `description:` without quotes unless punctuation requires single quotes
+- Do not specify textures in abstract prototypes
+- Use `# MARK: Topic Name` comments to separate logical sections in multi-section YAML files
+
+```yaml
+# MARK: Base Prototypes
+
+- type: entity
+  parent: BaseItem
+  id: STMessengerCartridge
+  name: st-messenger-cartridge-name
+  description: st-messenger-cartridge-description
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/cartridge.rsi
+    state: cart-y
+  - type: UIFragment
+    ui: !type:STMessengerUi
+  - type: Cartridge
+    programName: st-messenger-program-name
+  - type: STMessenger
+```
+
+### UI Code
+
+Always use **XAML over C#-defined UIs**. Extending existing C#-defined UIs is acceptable temporarily, but new UI should be XAML.
+
+## New Feature Directory Layout
+
+```
+Content.Shared/_Stalker_EN/YourFeature/
+    YourComponent.cs           # Component(s) - pure data
+    YourEvents.cs              # Event definitions
+    SharedYourSystem.cs        # Shared logic (if any)
+
+Content.Server/_Stalker_EN/YourFeature/
+    YourSystem.cs              # Server authoritative logic
+
+Content.Client/_Stalker_EN/YourFeature/
+    YourUi.cs                  # BUI / UI fragment
+    YourWindow.xaml            # XAML UI layout (always XAML, not C#)
+    YourWindow.xaml.cs         # Code-behind
+
+Resources/Prototypes/_Stalker_EN/YourFeature/
+    entities.yml               # Entity prototypes
+
+Resources/Locale/en-US/_Stalker_EN/yourfeature/
+    yourfeature.ftl            # Localization strings
+```
+
+Single-file systems do not need subfolders.
+
+## Contribution Workflow
+
+### Branch and PR Process
+
+1. Fork [coolmankid12345/stalker-14-EN](https://github.com/coolmankid12345/stalker-14-EN) and clone your fork
+2. Create a feature branch from `master`
+3. Follow the conventions on this page
+4. Test all changes in-game (not just compilation)
+5. Push to your fork and open a pull request against `master` on the main repo
+6. Address review feedback
+
+## Upstream References
+
+- [SS14 Codebase Conventions](https://docs.spacestation14.com/en/general-development/codebase-info/conventions.html): base rules this project inherits
+- [SS14 Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html): upstream PR expectations
+
+Where this page and the SS14 docs conflict, **this page takes precedence**.
+
+## Contributing to the Wiki
+
+Wiki source files live in `docs/wiki/` in the main repository. Edit or add `.md` files and submit a PR like any code change. A GitHub Action syncs `docs/wiki/` to the GitHub wiki on merge to `master`.
+
+### Page Conventions
+
+- **Filenames**: `Page-Name.md` (PascalCase words separated by hyphens)
+- **Link format**: `[Link Text](Page-Name)` (no `.md` extension)
+- **New feature pages**: Use the `stalker-wiki-writer` agent via Claude Code to generate documentation
+
+---
+
+[Back to Home](Home)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,35 @@
+# Stalker-14-EN Developer Wiki
+
+Stalker-14-EN is an English-language SS14 mod built on top of a closed Russian Stalker-14 fork. The main repository is [coolmankid12345/stalker-14-EN](https://github.com/coolmankid12345/stalker-14-EN). This wiki covers the EN-specific systems, conventions, and architecture.
+
+These pages focus on **why** systems exist, **how** they fit together, and **where** to look when you need to change something.
+
+## Quick Links
+
+| Resource | Link |
+|----------|------|
+| Discord | [Join the Discord](https://discord.gg/SnUSV76zR3) |
+| SS14 Developer Docs | [docs.spacestation14.com](https://docs.spacestation14.com/) |
+| Repository | [coolmankid12345/stalker-14-EN](https://github.com/coolmankid12345/stalker-14-EN) |
+
+## Getting Started
+
+- [Dev Environment Setup](https://docs.spacestation14.com/en/general-development/setup/setting-up-a-development-environment.html)
+- [Codebase Architecture](Codebase-Architecture)
+- [Contributing Guide](Contributing-Guide)
+
+## Features
+
+| Page | Description |
+|------|-------------|
+| [Mob Variant and Trophy System](Mob-Variant-and-Trophy-System) | Randomized mutant variants with tiered loot drops and trophy extraction |
+
+## Project Lineage
+
+```
+Space Station 14 (upstream engine + content)
+  +-- Stalker-14 (closed Russian fork)
+       +-- coolmankid12345/stalker-14-EN (English localization + new features)
+```
+
+All EN-specific code lives under `_Stalker_EN/` directories. Upstream Stalker code lives in `_Stalker/` directories. Base SS14 code sits outside both. This three-layer separation is the most important convention in the codebase. See [Codebase Architecture](Codebase-Architecture) for details.

--- a/docs/wiki/Mob-Variant-and-Trophy-System.md
+++ b/docs/wiki/Mob-Variant-and-Trophy-System.md
@@ -1,0 +1,389 @@
+# Mob Variant and Trophy System
+
+> Procedurally promotes spawned mutant mobs into quality tiers (Uncommon / Rare / Legendary) with scaled stats, visual tints, and higher-value trophy drops, giving the Zone its "rare hunt" loop without requiring unique sprite assets per variant.
+
+[< Back to Home](Home)
+
+## Motivation
+
+**Before this system**, every mob of a given species was mechanically identical. Creating "elite" mutants required hand-authoring entire new entity prototypes with different stats and sprites, then wiring them into every spawner and pack definition. That approach does not scale (28+ species, each needing 3-4 quality variants) and creates a maintenance burden where stat rebalancing requires touching dozens of files.
+
+**The design goal**: a content author adds a single `STMobVariantConfig` component to a mob prototype, defines probability/stat curves per tier, and the system handles everything at runtime: stat scaling, visual differentiation, loot replacement, weight variance, shop pricing, and examine text.
+
+## Design Decisions
+
+- **In-place mutation, not entity replacement**: When a mob is promoted, the system modifies the existing entity's components rather than despawning/respawning. This preserves `EntityUid` handles held by spawners and NPC pack references.
+
+- **Cumulative probability with early exit**: Variant chances are evaluated top-to-bottom as a cumulative distribution. If no variant hits, the mob stays Common. Ordering in `variants:` matters (higher-probability entries first). The system logs a warning if chances sum above 1.0.
+
+- **Config component is consumed on use**: `STMobVariantConfigComponent` is removed after MapInit processing. It exists only to carry YAML data into the system. Runtime state lives in `STMobVariantComponent`.
+
+- **Shader-based visuals, not unique sprites**: A fragment shader (`STMobTint`) adjusts brightness, saturation, and tint color per sprite layer. Adding visual variety to a new mob species is a YAML-only task.
+
+- **Spatial lookup for trophy inheritance**: When a trophy spawns from butchering, it needs the source mob's weight and shader parameters. Rather than modifying upstream `ButcherableSystem`, `STTrophyWeightSystem` performs a spatial lookup for the nearest mob within 2m. This avoids upstream code changes at the cost of a slightly fragile spatial assumption.
+
+- **Prototype parent-chain price resolution**: Variant trophy parts are children of the base mutant part (e.g., `STMutantPartUncommonBlindDogTail` parents `MutantPartBlindDogTail`). The sell-price resolver walks the prototype parent chain until it finds a listed ancestor, then applies `PriceMultiplier`. Shops only need to list base part IDs.
+
+## Mental Model
+
+Think of the system as a **post-spawn modifier pipeline**:
+
+```
+Mob spawns (MapInit)
+    |
+    v
+[STMobVariantSystem]   Roll dice against variant table
+    |                     If hit: scale HP, damage, speed thresholds, size, name, loot table
+    |                     Apply STMobVariantComponent with shader params
+    |                     Always: remove config component
+    v
+[STMobWeightVarianceSystem]   Randomize weight within tier-specific range
+    |                           (runs AFTER variant system via event ordering)
+    v
+Entity lives its life, looking visually distinct to clients via shader
+    |
+    v
+Mob dies, player butchers it
+    |
+    v
+Trophy item spawns with STTrophyComponent
+    |
+    v
+[STTrophyWeightSystem]   Spatial lookup copies mob weight + shader params to trophy
+    |
+    v
+[STTrophyExamineSystem]   Player examines trophy, sees colored quality label + weight
+    |
+    v
+[ShopSystem.TryResolveSellPrice]   Sell price = base ancestor price x PriceMultiplier
+```
+
+The **client side** is simpler: `STMobVariantSpriteSystem` and `STTrophySpriteSystem` both use `STMobTintHelper` to apply the shader to mob and trophy sprites respectively, triggered by networked component state updates.
+
+## Architecture
+
+### Component Roles
+
+| Component | Location | Lifetime | Purpose |
+|-----------|----------|----------|---------|
+| `STMobVariantConfigComponent` | Shared | MapInit only (removed after processing) | YAML-authored variant table: chances, multipliers, tint params, loot swaps |
+| `STMobVariantComponent` | Shared (networked) | Entity lifetime | Runtime marker: quality tier + shader params. Prevents re-rolling. Networks tint to clients |
+| `STMobWeightVarianceComponent` | Shared | MapInit only (removed after processing) | Weight randomization range. Variant system can override its min/max |
+| `STTrophyComponent` | Shared (networked) | Entity lifetime | Quality tier, price multiplier, source mob weight, inherited shader params |
+
+### System Roles
+
+| System | Side | Responsibility |
+|--------|------|----------------|
+| `STMobVariantSystem` | Server | Rolls variants on MapInit, applies stat/loot/visual modifications |
+| `STMobWeightVarianceSystem` | Server | Randomizes mob weight within a range (runs after variant system) |
+| `STTrophyWeightSystem` | Server | On trophy ComponentStartup, spatial-lookups nearest mob, copies weight + shader data |
+| `STTrophyExamineSystem` | Shared | Adds colored quality label and specimen weight to examine tooltip |
+| `STMobVariantSpriteSystem` | Client | Applies `STMobTint` shader to variant mob sprites |
+| `STTrophySpriteSystem` | Client | Applies `STMobTint` shader to trophy sprites |
+| `ShopSystem` (partial) | Server | `TryResolveSellPrice` walks prototype parents and applies `PriceMultiplier` |
+
+### Data Flow Diagram
+
+```mermaid
+graph TD
+    subgraph "Server - MapInit"
+        A[STMobVariantConfigComponent<br/>YAML variant table] -->|read by| B[STMobVariantSystem]
+        B -->|rolls variant| C{Hit?}
+        C -->|Yes| D[Apply stat multipliers<br/>HP, Damage, SlowOnDamage,<br/>Destructible triggers]
+        C -->|Yes| E[Swap butcher/destructible loot IDs]
+        C -->|Yes| F[Set name override<br/>Set sprite scale]
+        C -->|Yes| G[Override weight variance range]
+        D --> H[Add STMobVariantComponent<br/>with shader params]
+        E --> H
+        F --> H
+        G --> H
+        C -->|No| I[Mob stays Common]
+        H --> J[STMobWeightVarianceSystem<br/>randomizes weight]
+        I --> J
+    end
+
+    subgraph "Client - Rendering"
+        H -->|networked state| K[STMobVariantSpriteSystem]
+        K -->|via STMobTintHelper| L[STMobTint shader<br/>applied to all sprite layers]
+    end
+
+    subgraph "Server - Death & Loot"
+        M[Mob dies / butchered] -->|spawns| N[Trophy with STTrophyComponent]
+        N -->|ComponentStartup| O[STTrophyWeightSystem]
+        O -->|spatial lookup 2m| P[Copy mob weight +<br/>shader params to trophy]
+    end
+
+    subgraph "Client - Trophy Display"
+        P -->|networked state| Q[STTrophySpriteSystem]
+        Q -->|via STMobTintHelper| R[Same STMobTint shader<br/>on trophy sprite]
+    end
+
+    subgraph "Shared - Examine"
+        P --> S[STTrophyExamineSystem]
+        S --> T[Colored quality label +<br/>specimen weight in tooltip]
+    end
+
+    subgraph "Server - Economy"
+        N -->|sell to shop| U[ShopSystem.TryResolveSellPrice]
+        U -->|walks parent prototypes| V[Find base part price]
+        V -->|x PriceMultiplier| W[Final sell price]
+    end
+```
+
+### The STMobTint Shader
+
+The fragment shader (`Resources/Textures/Shaders/_Stalker_EN/st_mob_tint.swsl`) performs three operations in order:
+
+1. **Brightness**: Multiplies RGB by the brightness uniform (1.0 = no change)
+2. **Saturation**: Mixes between luminance-preserving greyscale and current color (0 = greyscale, 1 = original, >1 = vivid)
+3. **Tint**: Multiplicative color blend with the tint uniform
+
+This order matters: brightness before saturation ensures bright-but-desaturated variants (like Rare tier's washed-out look) render correctly.
+
+## Quality Tiers
+
+| Quality | In-game Name | Examine Color | Typical Chance | Stat Multipliers | Price Multiplier |
+|---------|-------------|---------------|----------------|------------------|-----------------|
+| Common | "Standard" | Gray `#808080` | ~90% (remainder) | 1.0x (no change) | 1.0x |
+| Uncommon | "Adapted" | Green `#00FF00` | ~8% | 1.1x HP, 1.1x Dmg | 1.5x |
+| Rare | "Mutated" | Blue `#4169E1` | ~2% | 1.2x HP, 1.2x Dmg | 3.7x |
+| Legendary | "Singular" | Gold `#FFD700` | ~0.1% | 1.3x HP, 1.3x Dmg | 11.1x |
+
+> **Warning**: These values are per-species, defined in each mob's YAML. The table above reflects the most common convention. Always check the specific prototype.
+
+### Visual Identity by Tier
+
+- **Uncommon ("Adapted")**: Warm/earthy tint, increased saturation, slightly darker. "Hardened survivors."
+- **Rare ("Mutated")**: Cool/pale tint, heavily desaturated, brighter. Unnaturally bleached or frost-touched.
+- **Legendary ("Singular")**: Vivid hot tint (reds, golds), high saturation, moderate brightness. Immediately alarming.
+
+## How to Extend
+
+### Adding variants to an existing mob species
+
+YAML-only task, no C# changes required.
+
+**Step 1**: Add `STMobVariantConfig` to the mob prototype:
+
+```yaml
+# e.g., Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T2/snork.yml
+- type: entity
+  id: MobMutantSnork
+  # ... existing components ...
+  # Stalker-EN start
+  - type: STMobVariantConfig
+    variants:
+    - chance: 0.08
+      quality: Uncommon
+      nameOverride: st-mob-variant-uncommon-snork
+      healthMultiplier: 1.1
+      damageMultiplier: 1.1
+      spriteScale: 1.05
+      spriteTint: "#604020FF"
+      spriteSaturation: 1.3
+      spriteBrightness: 0.8
+      minWeightMultiplier: 0.95
+      maxWeightMultiplier: 1.25
+      butcherSwaps:
+        MutantPartSnorkHand: STMutantPartUncommonSnorkHand
+    - chance: 0.02
+      quality: Rare
+      nameOverride: st-mob-variant-rare-snork
+      healthMultiplier: 1.2
+      damageMultiplier: 1.2
+      spriteScale: 1.1
+      spriteTint: "#C0D0FFFF"
+      spriteSaturation: 0.2
+      spriteBrightness: 1.5
+      minWeightMultiplier: 1.1
+      maxWeightMultiplier: 1.4
+      butcherSwaps:
+        MutantPartSnorkHand: STMutantPartRareSnorkHand
+    - chance: 0.001
+      quality: Legendary
+      nameOverride: st-mob-variant-legendary-snork
+      healthMultiplier: 1.3
+      damageMultiplier: 1.3
+      spriteScale: 1.15
+      spriteTint: "#FF3020FF"
+      spriteSaturation: 1.4
+      spriteBrightness: 1.2
+      minWeightMultiplier: 1.3
+      maxWeightMultiplier: 1.6
+      butcherSwaps:
+        MutantPartSnorkHand: STMutantPartLegendarySnorkHand
+  # Stalker-EN end
+```
+
+**Step 2**: Create variant trophy part prototypes (in `Resources/Prototypes/_Stalker_EN/Entities/Objects/MutantParts/`):
+
+```yaml
+# snork_variant_parts.yml
+- type: entity
+  parent: MutantPartSnorkHand
+  id: STMutantPartUncommonSnorkHand
+  name: Adapted Snork Hand
+  description: A snork hand showing signs of advanced Zone adaptation...
+  components:
+  - type: STTrophy
+    quality: Uncommon
+    priceMultiplier: 1.5
+
+- type: entity
+  parent: MutantPartSnorkHand
+  id: STMutantPartRareSnorkHand
+  name: Mutated Snork Hand
+  description: An eerily pale snork hand with crystalline growths...
+  components:
+  - type: STTrophy
+    quality: Rare
+    priceMultiplier: 3.7
+
+- type: entity
+  parent: MutantPartSnorkHand
+  id: STMutantPartLegendarySnorkHand
+  name: Singular Snork Hand
+  description: A blood-red snork hand that pulses with residual warmth...
+  components:
+  - type: STTrophy
+    quality: Legendary
+    priceMultiplier: 11.1
+```
+
+**Step 3**: Add locale strings (in `Resources/Locale/en-US/_Stalker_EN/trophy/trophy.ftl`):
+
+```
+st-mob-variant-uncommon-snork = Adapted Snork
+st-mob-variant-rare-snork = Mutated Snork
+st-mob-variant-legendary-snork = Singular Snork
+```
+
+**Step 4**: Create GM-spawnable variant prototypes (in `Resources/Prototypes/_Stalker_EN/Entities/Mobs/Mutants/T2/`):
+
+```yaml
+# snork_variants.yml
+- type: entity
+  parent: MobMutantSnork
+  id: STMobMutantSnorkCommon
+  name: Snork
+  suffix: ST, T2, Common
+  components:
+  - type: STMobVariant
+    quality: Common
+    applied: true    # Already processed, no re-rolling
+
+- type: entity
+  parent: MobMutantSnork
+  id: STMobMutantSnorkUncommon
+  name: Adapted Snork
+  suffix: ST, T2, Adapted
+  components:
+  - type: STMobVariant
+    quality: Uncommon  # applied defaults to false; system finds matching entry and applies
+
+- type: entity
+  parent: MobMutantSnork
+  id: STMobMutantSnorkRare
+  name: Mutated Snork
+  suffix: ST, T2, Mutated
+  components:
+  - type: STMobVariant
+    quality: Rare
+
+- type: entity
+  parent: MobMutantSnork
+  id: STMobMutantSnorkLegendary
+  name: Singular Snork
+  suffix: ST, T2, Singular
+  components:
+  - type: STMobVariant
+    quality: Legendary
+```
+
+> **Tip**: GM-spawnable variants use `STMobVariantComponent` with a specific `quality` but `applied: false`. On MapInit, `STMobVariantSystem` detects the pre-existing component, looks up the matching variant entry, and applies those stats deterministically. The Common variant sets `applied: true` to skip processing entirely.
+
+### Integrating a new loot drop mechanism
+
+If a mob drops parts through `DestructibleComponent` (`SpawnEntitiesBehavior`) instead of `ButcherableComponent`, the variant system already handles this. `SwapDestructibleLoot` mirrors `SwapButcherableLoot`. Use the same `butcherSwaps` map in YAML.
+
+### Adjusting balance
+
+All balance levers are in YAML. There is no global multiplier (intentional, because a 1.2x HP boost on a 50 HP blind dog differs greatly from 1.2x on a 2300 HP chimera). Content authors tune per-species.
+
+## Gotchas
+
+### Event ordering between variant and weight systems
+
+`STMobWeightVarianceSystem` subscribes to `MapInitEvent` with `after: [typeof(STMobVariantSystem)]`. This is critical because the variant system may override weight variance min/max values. If the weight system ran first, it would use default ranges for every tier.
+
+For new systems that need to run after variant processing:
+
+```csharp
+SubscribeLocalEvent<YourComponent, MapInitEvent>(OnMapInit, after: [typeof(STMobVariantSystem)]);
+```
+
+### Trophy spatial lookup radius
+
+`STTrophyWeightSystem` searches within `2.0f` meters. If two mobs die near each other and both are butchered, a trophy could pick up the wrong mob's data. In practice this is rare due to DoAfter timing.
+
+### The `Applied` flag prevents double-processing
+
+`STMobVariantComponent.Applied` serves two purposes:
+1. Set to `true` in YAML (Common GM-spawnable variants): tells the system "already done, skip."
+2. Set to `false` with a specific `Quality` (non-Common GM-spawnable variants): tells the system "apply the matching variant entry deterministically."
+
+### Variant trophy parts must parent the base part
+
+The shop price resolution walks the prototype parent chain. If a variant part does not eventually parent the base part listed in shops, it will not be sellable.
+
+### The config component is removed after MapInit
+
+Do not read `STMobVariantConfigComponent` at runtime. All runtime state is on `STMobVariantComponent`. To check what variants were possible, look up the original prototype.
+
+### Shader caching in client systems
+
+`STMobVariantSpriteSystem` and `STTrophySpriteSystem` maintain per-entity shader parameter caches to avoid recreating shader instances on every PVS update. Caches are cleaned on `ComponentRemove`. If a mob's tint does not update, verify `Dirty()` is being called on the server.
+
+### DestructibleComponent is server-only
+
+When the variant system scales `DamageTrigger` thresholds or swaps `SpawnEntitiesBehavior` entries in `DestructibleComponent`, it does not call `Dirty()`. This is correct: `DestructibleComponent` is not networked.
+
+### ButcherableComponent *is* networked
+
+After swapping loot entries, the system calls `Dirty(uid, butcherable)`. If you add new modifications to butcherable data, remember to dirty it.
+
+## Related Systems
+
+| System | Relationship |
+|--------|-------------|
+| **STWeightSystem** (`Content.Shared/_Stalker/Weight/`) | Variant system modifies `STWeightComponent.Self` indirectly via `STMobWeightVarianceSystem`. Trophy system reads it for examine display. |
+| **MobThresholdSystem** | Used to scale HP thresholds programmatically. |
+| **SharedScaleVisualsSystem** | Used for sprite scaling. Variant system multiplies against existing scale. |
+| **ButcherableSystem** | Upstream butchering system. Variant system modifies its spawned entity list. The spatial lookup avoids changing the butcher event chain. |
+| **ShopSystem** (`Content.Server/_Stalker/Shop/`) | `ShopSystem.Trophy.cs` adds `TryResolveSellPrice` for trophy pricing integration. |
+| **DestructibleSystem** | Some mobs drop parts through destructible behaviors. Variant system swaps these entries too. |
+
+## Key Files Reference
+
+| File | Purpose |
+|------|---------|
+| `Content.Shared/_Stalker_EN/MobVariant/STMobVariantConfigComponent.cs` | YAML-authored variant table (consumed on init) |
+| `Content.Shared/_Stalker_EN/MobVariant/STMobVariantComponent.cs` | Runtime networked marker: quality + shader params |
+| `Content.Shared/_Stalker_EN/MobVariant/STMobWeightVarianceComponent.cs` | Weight randomization range |
+| `Content.Server/_Stalker_EN/MobVariant/STMobVariantSystem.cs` | Core server logic: roll variants, apply modifications |
+| `Content.Server/_Stalker_EN/MobVariant/STMobWeightVarianceSystem.cs` | Server weight randomizer (runs after variant system) |
+| `Content.Shared/_Stalker_EN/Trophy/STTrophyComponent.cs` | Trophy data: quality, price multiplier, source weight, shader params |
+| `Content.Shared/_Stalker_EN/Trophy/STTrophyQuality.cs` | `enum STTrophyQuality { Common, Uncommon, Rare, Legendary }` |
+| `Content.Shared/_Stalker_EN/Trophy/STTrophyExamineSystem.cs` | Colored quality label + weight in examine tooltip |
+| `Content.Server/_Stalker_EN/Trophy/STTrophyWeightSystem.cs` | Spatial lookup: copies mob data to trophy at spawn |
+| `Content.Server/_Stalker_EN/Shop/ShopSystem.Trophy.cs` | Prototype parent-chain price resolution with trophy multiplier |
+| `Content.Client/_Stalker_EN/MobVariant/STMobVariantSpriteSystem.cs` | Applies STMobTint shader to variant mob sprites |
+| `Content.Client/_Stalker_EN/Trophy/STTrophySpriteSystem.cs` | Applies STMobTint shader to trophy sprites |
+| `Content.Client/_Stalker_EN/Shaders/STMobTintHelper.cs` | Shared shader application logic with per-entity caching |
+| `Resources/Textures/Shaders/_Stalker_EN/st_mob_tint.swsl` | Fragment shader: brightness, saturation, tint |
+| `Resources/Prototypes/_Stalker_EN/Shaders/st_mob_tint.yml` | Shader prototype definition |
+| `Resources/Locale/en-US/_Stalker_EN/trophy/trophy.ftl` | Trophy quality names and variant mob name overrides |
+| `Resources/Prototypes/_Stalker_EN/Entities/Mobs/Mutants/` | Per-tier variant mob prototypes (GM-spawnable) |
+| `Resources/Prototypes/_Stalker_EN/Entities/Objects/MutantParts/` | Variant trophy part prototypes |
+| `Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/base.yml` | Base mutant prototype (has `STMobWeightVariance`) |

--- a/docs/wiki/_Footer.md
+++ b/docs/wiki/_Footer.md
@@ -1,0 +1,3 @@
+---
+
+[Stalker-14-EN](https://github.com/coolmankid12345/stalker-14-EN) | [SS14 Developer Docs](https://docs.spacestation14.com/)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,15 @@
+### [Home](Home)
+
+---
+
+### Getting Started
+
+- [Dev Environment Setup](https://docs.spacestation14.com/en/general-development/setup/setting-up-a-development-environment.html)
+- [Codebase Architecture](Codebase-Architecture)
+- [Contributing Guide](Contributing-Guide)
+
+---
+
+### Features
+
+- [Mob Variant & Trophy System](Mob-Variant-and-Trophy-System)


### PR DESCRIPTION
## What I changed

My attempt at making some kind of wiki for this repo. Github Actions should auto update the wiki. 

- **Home.md** - Wiki landing page with navigation
- **Contributing-Guide.md** - Developer onboarding guide covering ECS patterns, code placement, and conventions
- **Codebase-Architecture.md** - Project structure overview and key systems reference
- **Mob-Variant-and-Trophy-System.md** - Documentation for the mob variant/trophy system
- **_Sidebar.md / _Footer.md** - Wiki navigation
- **wiki-sync.yml** - GitHub Actions workflow to sync `docs/wiki/` to the repo wiki on push

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
