### PR TITLE
fix: correct blocker area coordinates and cleanup in anomaly generation

### DIFF
--- a/Content.Server/_Stalker/Anomaly/Generation/Jobs/STAnomalyGenerationJob.cs
+++ b/Content.Server/_Stalker/Anomaly/Generation/Jobs/STAnomalyGenerationJob.cs
@@ -143,9 +143,9 @@ public sealed partial class STAnomalyGenerationJob : Job<STAnomalyGenerationJobD
                 continue;
 
             var position = _transform.GetWorldPosition(transform);
-            var coordinates = new Vector2i((int) position.X, (int) position.Y);
+            var coordinates = new Vector2i((int) Math.Floor(position.X), (int) Math.Floor(position.Y));
             var size = blocker.Size;
-            blockerAreas.Add(new Box2i(coordinates.X - size, coordinates.Y - size, coordinates.X + size + 1, coordinates.Y + size));
+            blockerAreas.Add(new Box2i(coordinates.X - size, coordinates.Y - size, coordinates.X + size + 1, coordinates.Y + size + 1));
         }
 
         var coordinatesToRemove = new List<Vector2i>();
@@ -170,6 +170,7 @@ public sealed partial class STAnomalyGenerationJob : Job<STAnomalyGenerationJobD
         foreach (var coord in coordinatesToRemove)
         {
             _tileCoordinates.Remove(coord);
+            _tileCoordinatesSpawn.Remove(coord);
         }
     }
     // stalker-en-changes-end


### PR DESCRIPTION
## What I changed

Fixed anomaly generation blocker area coordinate calculations in `STAnomalyGenerationJob.cs`:
- Used `Math.Floor` instead of integer cast for position-to-tile coordinate conversion, which handles negative coordinates correctly
- Fixed `Box2i` constructor to add +1 to the Y max bound, making the blocker area symmetrical
- Added missing `_tileCoordinatesSpawn.Remove(coord)` call so blocked tiles are also removed from the spawn list

## Changelog

author: @teecoding

- fix: Anomaly generation blockers now correctly exclude tiles in all directions

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
