### PR TITLE
feat(prayer): add teleport links to admin notifications

### DIFF
--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Bible.Components;
@@ -10,6 +11,7 @@ using Content.Shared.Prayer;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Prayer;
 /// <summary>
@@ -58,7 +60,7 @@ public sealed class PrayerSystem : EntitySystem
                 {
                     // Make sure the player's entity and the Prayable entity+component still exist
                     if (actor?.PlayerSession != null && HasComp<PrayableComponent>(uid))
-                        Pray(actor.PlayerSession, comp, message);
+                        Pray(actor.PlayerSession, comp, message, uid);
                 });
             },
             Impact = LogImpact.Low,
@@ -97,7 +99,7 @@ public sealed class PrayerSystem : EntitySystem
     /// You may be wondering, "Why the admin chat, specifically? Nobody even reads it!"
     /// Exactly.
     ///  </remarks>
-    public void Pray(ICommonSession sender, PrayableComponent comp, string message)
+    public void Pray(ICommonSession sender, PrayableComponent comp, string message, EntityUid altar)
     {
         if (sender.AttachedEntity == null)
             return;
@@ -106,5 +108,27 @@ public sealed class PrayerSystem : EntitySystem
 
         _chatManager.SendAdminAnnouncement($"{Loc.GetString(comp.NotificationPrefix)} <{sender.Name}>: {message}");
         _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(sender.AttachedEntity.Value):player} sent prayer ({Loc.GetString(comp.NotificationPrefix)}): {message}");
+
+        // Send clickable teleport links to admins
+        var links = new StringBuilder();
+
+        if (sender.AttachedEntity is { } playerEntity)
+        {
+            var playerNet = GetNetEntity(playerEntity);
+            var playerName = FormattedMessage.EscapeText(sender.Name).Replace("\"", "\\\"");
+            links.Append($"[cmdlink=\"TP: {playerName}\" command=\"tpto {playerNet}\"/]");
+        }
+
+        if (altar.Valid)
+        {
+            if (links.Length > 0)
+                links.Append(' ');
+            var altarNet = GetNetEntity(altar);
+            var altarName = FormattedMessage.EscapeText(Name(altar)).Replace("\"", "\\\"");
+            links.Append($"[cmdlink=\"TP: {altarName}\" command=\"tpto {altarNet}\"/]");
+        }
+
+        if (links.Length > 0)
+            _chatManager.SendAdminAlertNoFormatOrEscape(links.ToString());
     }
 }


### PR DESCRIPTION
## What I changed

Added clickable teleport links to admin chat when a player sends a prayer. Admins now see "TP: PlayerName" and "TP: AltarName" buttons that teleport them directly to the praying player or the altar used.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
