### PR TITLE
fix: exclude Monolith from PDA covert faction override

### DIFF
--- a/Content.Server/_Stalker_EN/BulletinBoard/STBulletinBoardSystem.cs
+++ b/Content.Server/_Stalker_EN/BulletinBoard/STBulletinBoardSystem.cs
@@ -34,7 +34,7 @@ public sealed class STBulletinBoardSystem : EntitySystem
     [Dependency] private readonly SharedSTFactionResolutionSystem _factionResolution = default!;
     [Dependency] private readonly STMessengerSystem _messenger = default!;
 
-    private static readonly ProtoId<STBandPrototype> MonolithBandId = "STMonolithBand";
+    private static readonly ProtoId<STBandPrototype> ClearSkyBandId = "STClearSkyBand";
 
     /// <summary>
     /// Offers grouped by board type ID, then keyed by offer ID.
@@ -611,8 +611,8 @@ public sealed class STBulletinBoardSystem : EntitySystem
         if (!TryComp<BandsComponent>(uid, out var bands))
             return null;
 
-        // Covert factions (CanChange = true) appear as Loners, except Monolith who shows their real faction
-        if (bands.CanChange && bands.BandProto != MonolithBandId)
+        // Only Clear Sky is disguised as Loners on PDA
+        if (bands.BandProto == ClearSkyBandId)
             return _factionResolution.GetBandFactionName(bands.BandName);
 
         if (bands.BandProto is not { } bandProtoId)

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -52,7 +52,7 @@ public sealed partial class STMessengerSystem : EntitySystem
     private const int MaxRetryCollision = 10;
     private const int MaxPseudonymSuffix = 999;
     private static readonly TimeSpan InteractionCooldown = TimeSpan.FromSeconds(0.5);
-    private static readonly ProtoId<STBandPrototype> MonolithBandId = "STMonolithBand";
+    private static readonly ProtoId<STBandPrototype> ClearSkyBandId = "STClearSkyBand";
 
     /// <summary>
     /// Maps (userId, charName) → anonymous pseudonym for the current round.
@@ -911,8 +911,8 @@ public sealed partial class STMessengerSystem : EntitySystem
         if (!TryComp<BandsComponent>(holder, out var bands))
             return null;
 
-        // Covert factions (CanChange = true) appear as Loners on PDA, except Monolith who shows their real faction
-        if (bands.CanChange && bands.BandProto != MonolithBandId)
+        // Only Clear Sky is disguised as Loners on PDA
+        if (bands.BandProto == ClearSkyBandId)
             return _factionResolution.GetBandFactionName(bands.BandName);
 
         if (bands.BandProto is not { } bandProtoId)


### PR DESCRIPTION
## What I changed                                                                                                                                                                                                                          
   
  Only Clear Sky is now disguised as Loners on PDA messenger and bulletin board. All other factions (Monolith, Military, Project, SSU) show their real faction patch.                                                                        
                                                            
  ## Changelog

  author: @teecoding

  - fix: only Clear Sky is disguised as Loners on PDA; Monolith, Military, Project, and SSU now show their real faction patch

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
