### PR TITLE
feat: hide Journalists from PDA and Igor faction relations UIs

### DIFF
--- a/Content.Server/_Stalker/Bands/BandsSystem.cs
+++ b/Content.Server/_Stalker/Bands/BandsSystem.cs
@@ -198,7 +198,7 @@ namespace Content.Server._Stalker.Bands
             var allFactions = new List<string>();
             foreach (var f in relationsState.FactionIds)
             {
-                if (!_factionRelations.IsAlias(f) && !_factionRelations.IsFactionRestricted(f))
+                if (!_factionRelations.IsAlias(f) && !_factionRelations.IsFactionRestricted(f) && !_factionRelations.IsFactionHidden(f))
                     allFactions.Add(f);
             }
 

--- a/Content.Server/_Stalker_EN/FactionRelations/STFactionRelationsCartridgeSystem.cs
+++ b/Content.Server/_Stalker_EN/FactionRelations/STFactionRelationsCartridgeSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.CartridgeLoader;
 using Content.Server.Chat.Systems;
 using Content.Server.Database;
@@ -81,6 +82,11 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
     /// Factions that cannot be targeted by player-initiated relation changes.
     /// </summary>
     private HashSet<string> _cachedRestrictedFactions = new();
+
+    /// <summary>
+    /// Factions hidden from all relation UIs (PDA app grid, Igor Relations tab).
+    /// </summary>
+    private HashSet<string> _cachedHiddenFactions = new();
 
     /// <summary>
     /// Tracks loaders (PDAs) that currently have the faction relations cartridge active.
@@ -207,6 +213,7 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         _aliasToPrimary = new Dictionary<string, string>();
         _primaryToAliases = new Dictionary<string, List<string>>();
         _cachedRestrictedFactions = new HashSet<string>();
+        _cachedHiddenFactions = new HashSet<string>();
         _cachedFactionIds = null;
 
         if (!_protoManager.TryIndex(DefaultsProtoId, out var proto))
@@ -222,6 +229,7 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         }
 
         _cachedRestrictedFactions = new HashSet<string>(proto.RestrictedFactions);
+        _cachedHiddenFactions = new HashSet<string>(proto.HiddenFactions);
 
         // Keep full faction list — filtering for specific UIs is done at the caller level
         _cachedFactionIds = proto.Factions;
@@ -326,7 +334,7 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         if (!_protoManager.TryIndex(DefaultsProtoId, out var defaults))
             return new STFactionRelationsUiState(new List<string>(), new List<STFactionRelationEntry>());
 
-        var factions = defaults.Factions;
+        var factions = defaults.Factions.Where(f => !_cachedHiddenFactions.Contains(f)).ToList();
         var entries = new List<STFactionRelationEntry>();
 
         for (var i = 0; i < factions.Count; i++)
@@ -452,6 +460,14 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
     {
         var resolved = ResolvePrimary(faction);
         return _cachedRestrictedFactions.Contains(resolved);
+    }
+
+    /// <summary>
+    /// Returns true if the faction is hidden from relation UIs.
+    /// </summary>
+    public bool IsFactionHidden(string faction)
+    {
+        return _cachedHiddenFactions.Contains(faction);
     }
 
     #endregion

--- a/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationDefaultsPrototype.cs
+++ b/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationDefaultsPrototype.cs
@@ -52,6 +52,13 @@ public sealed class STFactionRelationDefaultsPrototype : IPrototype
     public List<string> RestrictedFactions { get; } = new();
 
     /// <summary>
+    /// Factions hidden from all relation UIs (PDA app grid, Igor Relations tab).
+    /// Unlike aliases, hidden factions are independent — they just don't appear in UI.
+    /// </summary>
+    [DataField]
+    public List<string> HiddenFactions { get; } = new();
+
+    /// <summary>
     /// Maps faction IDs to human-readable display names.
     /// Only factions that differ from their ID need an entry (e.g. "ClearSky" → "Clear Sky").
     /// Factions without an entry use their ID as-is.

--- a/Resources/Prototypes/_Stalker_EN/FactionRelations/defaults.yml
+++ b/Resources/Prototypes/_Stalker_EN/FactionRelations/defaults.yml
@@ -38,6 +38,8 @@
   restrictedFactions:
     - Loners
     - Monolith
+  hiddenFactions:
+    - Journalists
   displayNames:
     ClearSky: Clear Sky
   relations:


### PR DESCRIPTION
## What I changed

  Journalists no longer appear in the PDA faction relations app grid or Igor's Relations tab. They still resolve correctly as a Loners alias for relation lookups.                                                                           
   
  Added a `hiddenFactions` list to the faction relation defaults prototype so specific factions can be excluded from relation UIs without affecting alias logic.                                                                             
                                                            
  ## Changelog

  author: @teecoding

  - tweak: Journalists are no longer shown in the PDA faction relations app or Igor's Relations tab

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license

