### PR TITLE
fix: use map coordinates for projectile distance calculation

### DIFF
--- a/Content.Shared/_Stalker/Weapon/Projectile/STProjectileSystem.cs
+++ b/Content.Shared/_Stalker/Weapon/Projectile/STProjectileSystem.cs
@@ -43,7 +43,12 @@ public sealed class STProjectileSystem : EntitySystem
         if (ent.Comp.StartCoordinates is null || ent.Comp.MinRemainingDamageModifier < 0)
             return;
 
-        var distance = (_transform.GetMoverCoordinates(args.Target).Position - ent.Comp.StartCoordinates.Value.Position).Length();
+        // stalker-changes: use map coordinates to avoid cross-grid distance errors
+        var startMapPos = _transform.ToMapCoordinates(ent.Comp.StartCoordinates.Value);
+        var targetMapPos = _transform.GetMapCoordinates(args.Target);
+        if (startMapPos.MapId != targetMapPos.MapId)
+            return;
+        var distance = (targetMapPos.Position - startMapPos.Position).Length();
         var minDamage = args.Damage.GetTotal() * ent.Comp.MinRemainingDamageModifier;
 
         foreach (var threshold in ent.Comp.Thresholds)
@@ -78,8 +83,12 @@ public sealed class STProjectileSystem : EntitySystem
             return;
 
         var accuracy = ent.Comp.Accuracy;
-        var targetCoordinates = _transform.GetMoverCoordinates(args.OtherEntity);
-        var distance = (targetCoordinates.Position - ent.Comp.StartCoordinates.Value.Position).Length();
+        // stalker-changes: use map coordinates to avoid cross-grid distance errors
+        var startMapPos = _transform.ToMapCoordinates(ent.Comp.StartCoordinates.Value);
+        var targetMapPos = _transform.GetMapCoordinates(args.OtherEntity);
+        if (startMapPos.MapId != targetMapPos.MapId)
+            return;
+        var distance = (targetMapPos.Position - startMapPos.Position).Length();
 
         foreach (var threshold in ent.Comp.Thresholds)
         {


### PR DESCRIPTION
## What I changed

Fixed projectile damage falloff and accuracy distance calculations using wrong reference frames when shooter and target are on different grids. Changed both calculations to use world-space (map) coordinates so distance is always correct regardless of grid positions.                                                                             
                                                           
## Changelog
author: @teecoding
- fix: Fixed inconsistent weapon damage at range caused by incorrect distance calculations across grids

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are
under an open license