### PR TITLE
fix: prevent BaseModifiers mutation and double-stacking in STArmorLevels damage calculation

### DIFF
--- a/Content.Shared/Armor/STArmorLevels.cs
+++ b/Content.Shared/Armor/STArmorLevels.cs
@@ -6,6 +6,20 @@ namespace Content.Shared.Armor;
 [DataDefinition, Serializable, NetSerializable, Virtual]
 public partial class STArmorLevels
 {
+    // stalker-en-changes-start
+    private static readonly string[] NonPvPPhysicalTypes = ["Blunt", "Slash"];
+    private static readonly string[] PiercingTypes = ["Piercing"];
+    private static readonly string[] RadiationTypes = ["Radiation"];
+    private static readonly string[] EnvironmentTypes = ["Heat", "Caustic", "Shock", "Compression", "Psy"];
+    private static readonly string[] HeatTypes = ["Heat"];
+    private static readonly string[] CausticTypes = ["Caustic"];
+    private static readonly string[] ShockTypes = ["Shock"];
+    private static readonly string[] PsyTypes = ["Psy"];
+
+    private const float CoefficientAdjustPerLevel = -0.025f;
+    private const float FlatReductionScalePerLevel = 0.5f;
+    // stalker-en-changes-end
+
     // Generic
     [DataField("nonPvPPhysical")]
     public int NonPvPPhysicalAdjust = 0;
@@ -32,35 +46,51 @@ public partial class STArmorLevels
     [DataField("psy")]
     public int PsyAdjust = 0;
 
+    // stalker-en-changes-start
+    /// <summary>
+    /// Applies armor level adjustments to a base modifier set, returning a new set.
+    /// The original <paramref name="baseModifiers"/> is not mutated.
+    /// Generic adjustments are applied first, then exact type adjustments stack additively on top.
+    /// </summary>
     public DamageModifierSet ApplyLevels(DamageModifierSet baseModifiers)
     {
-        var newModifiers = new DamageModifierSet();
-        newModifiers = ApplyLevelToGroup(baseModifiers, NonPvPPhysicalAdjust, new[] { "Blunt", "Slash" });
-        newModifiers = ApplyLevelToGroup(newModifiers, PiercingAdjust, new[] { "Piercing" });
-        newModifiers = ApplyLevelToGroup(newModifiers, RadiationAdjust, new[] { "Radiation" });
-        newModifiers = ApplyLevelToGroup(newModifiers, EnvironmentAdjust, new[] { "Heat", "Caustic", "Shock", "Compression", "Psy" });
+        var newModifiers = new DamageModifierSet
+        {
+            Coefficients = new Dictionary<string, float>(baseModifiers.Coefficients),
+            FlatReduction = new Dictionary<string, float>(baseModifiers.FlatReduction),
+        };
 
-        newModifiers = ApplyLevelToGroup(baseModifiers, HeatAdjust, new[] { "Heat" });
-        newModifiers = ApplyLevelToGroup(newModifiers, CausticAdjust, new[] { "Caustic" });
-        newModifiers = ApplyLevelToGroup(newModifiers, ShockAdjust, new[] { "Shock" });
-        newModifiers = ApplyLevelToGroup(newModifiers, PsyAdjust, new[] { "Psy" });
+        // Generic adjustments
+        ApplyLevelToGroup(newModifiers, NonPvPPhysicalAdjust, NonPvPPhysicalTypes);
+        ApplyLevelToGroup(newModifiers, PiercingAdjust, PiercingTypes);
+        ApplyLevelToGroup(newModifiers, RadiationAdjust, RadiationTypes);
+        ApplyLevelToGroup(newModifiers, EnvironmentAdjust, EnvironmentTypes);
+
+        // Exact adjustments (stack additively on top of generic)
+        ApplyLevelToGroup(newModifiers, HeatAdjust, HeatTypes);
+        ApplyLevelToGroup(newModifiers, CausticAdjust, CausticTypes);
+        ApplyLevelToGroup(newModifiers, ShockAdjust, ShockTypes);
+        ApplyLevelToGroup(newModifiers, PsyAdjust, PsyTypes);
         return newModifiers;
     }
 
-    private DamageModifierSet ApplyLevelToGroup(DamageModifierSet modifiers, int level, string[] damageTypes)
+    private void ApplyLevelToGroup(DamageModifierSet modifiers, int level, string[] damageTypes)
     {
+        if (level == 0)
+            return;
+
         foreach (var damageType in damageTypes)
         {
             if (modifiers.Coefficients.TryGetValue(damageType, out var coefficient))
             {
-                modifiers.Coefficients[damageType] = MathF.Round(Math.Clamp(coefficient + (level * -0.025f), 0f, 1f), 2);
+                modifiers.Coefficients[damageType] = MathF.Round(Math.Clamp(coefficient + (level * CoefficientAdjustPerLevel), 0f, 1f), 2);
             }
 
             if (modifiers.FlatReduction.TryGetValue(damageType, out var flatReduction))
             {
-                modifiers.FlatReduction[damageType] = MathF.Round(flatReduction + flatReduction * (level * 0.5f), 2);
+                modifiers.FlatReduction[damageType] = MathF.Round(flatReduction + flatReduction * (level * FlatReductionScalePerLevel), 2);
             }
         }
-        return modifiers;
     }
+    // stalker-en-changes-end
 }

--- a/Content.Shared/Armor/STSharedArmorSystem.cs
+++ b/Content.Shared/Armor/STSharedArmorSystem.cs
@@ -1,9 +1,4 @@
 using Content.Shared.Damage;
-using Content.Shared.Examine;
-using Content.Shared.Inventory;
-using Content.Shared.Silicons.Borgs;
-using Content.Shared.Verbs;
-using Robust.Shared.Utility;
 
 namespace Content.Shared.Armor;
 
@@ -14,17 +9,25 @@ public abstract partial class SharedArmorSystem : EntitySystem
         ApplyLevels(component);
     }
 
+    // stalker-en-changes-start
+    /// <summary>
+    /// Computes effective damage modifiers by applying armor level adjustments to the base modifiers.
+    /// If no armor levels are defined, copies the base modifiers directly.
+    /// </summary>
     public void ApplyLevels(ArmorComponent component)
     {
-        component.Modifiers = new DamageModifierSet
-        {
-            Coefficients = new Dictionary<string, float>(component.BaseModifiers.Coefficients),
-            FlatReduction = new Dictionary<string, float>(component.BaseModifiers.FlatReduction)
-        };
-
         if (component.STArmorLevels != null)
         {
             component.Modifiers = component.STArmorLevels.ApplyLevels(component.BaseModifiers);
         }
+        else
+        {
+            component.Modifiers = new DamageModifierSet
+            {
+                Coefficients = new Dictionary<string, float>(component.BaseModifiers.Coefficients),
+                FlatReduction = new Dictionary<string, float>(component.BaseModifiers.FlatReduction),
+            };
+        }
     }
+    // stalker-en-changes-end
 }


### PR DESCRIPTION
## What I changed
Fixed armor level damage calculation bug where `BaseModifiers` was being mutated and exact-type adjustments (Heat, Caustic, Shock, Psy) were double-stacking instead of building on top of generic adjustments. Extracted magic values into constants and static arrays.

## Changelog

author: @teecoding

- fix: Armor level modifiers now calculate correctly and no longer stack improperly

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
