### PR TITLE
fix: prioritize fuller magazines in loadout stash selection

### DIFF
--- a/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
+++ b/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
@@ -1438,14 +1438,33 @@ public sealed class LoadoutSystem : EntitySystem
 
         // Fallback to prototype match - return ANY item with count > 0
         // This handles state-based identifier mismatches (stack counts, ammo counts, charges)
-        // Prefer items at the end of the list (most recently added)
+        // For magazines, prefer the fullest one (highest AmmoCount)
         if (lookup.ByPrototype.TryGetValue(prototypeId, out var protoList))
         {
+            RepositoryItemInfo? best = null;
+            var bestAmmo = -1;
+
             for (var i = protoList.Count - 1; i >= 0; i--)
             {
-                if (protoList[i].Count > 0)
+                if (protoList[i].Count <= 0)
+                    continue;
+
+                if (protoList[i].SStorageData is AmmoContainerStalker ammo)
+                {
+                    if (ammo.AmmoCount > bestAmmo)
+                    {
+                        bestAmmo = ammo.AmmoCount;
+                        best = protoList[i];
+                    }
+                }
+                else
+                {
+                    // Non-magazine items: return first available (existing behavior)
                     return protoList[i];
+                }
             }
+
+            return best;
         }
 
         return null;


### PR DESCRIPTION
## What I changed
When equipping loadouts, the stash lookup now prioritizes fuller magazines over partially empty ones. Previously it just grabbed the most recently added item; now it compares `AmmoCount` across all matching magazine entries and picks the fullest.

## Changelog

author: @teecoding

- fix: Loadout now equips the fullest available magazine instead of a random one

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
