### PR TITLE
feat(chat): add whisper-style obfuscation for wall-muffled speech

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -716,9 +716,15 @@ public new const int VoiceRange = 15; // how far voice goes in world units
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
 
             // Stalker-chat-start
-            var ev = new STChatMessageOverrideInVoiceRangeEvent(session, channel, source, message, wrappedMessage, entHideChat);
+            // stalker-en-changes-start: voice occlusion support
+            var ev = new STChatMessageOverrideInVoiceRangeEvent(
+                session, channel, source, message, wrappedMessage, entHideChat,
+                data.Range, data.Observer, data.HideChatOverride);
             RaiseLocalEvent(session.AttachedEntity ?? source, ref ev);
+            if (ev.Cancelled)
+                continue;
             _chatManager.ChatMessageToOne(channel, ev.Message, ev.WrappedMessage, source, ev.EntHideChat, session.Channel, author: author);
+            // stalker-en-changes-end
             // Stalker-chat-end
         }
 

--- a/Content.Server/_Stalker/Chat/STChatMessageOverrideInVoiceRangeEvent.cs
+++ b/Content.Server/_Stalker/Chat/STChatMessageOverrideInVoiceRangeEvent.cs
@@ -4,4 +4,16 @@ using Robust.Shared.Player;
 namespace Content.Server._Stalker.Chat;
 
 [ByRefEvent]
-public record struct STChatMessageOverrideInVoiceRangeEvent(ICommonSession HearingSession, ChatChannel Channel, EntityUid Source, string Message, string WrappedMessage, bool EntHideChat);
+public record struct STChatMessageOverrideInVoiceRangeEvent(
+    ICommonSession HearingSession,
+    ChatChannel Channel,
+    EntityUid Source,
+    string Message,
+    string WrappedMessage,
+    bool EntHideChat,
+    float Range = -1f,              // stalker-en-changes: distance from source to listener
+    bool Observer = false,           // stalker-en-changes: listener is a ghost/observer
+    bool? HideChatOverride = null)   // stalker-en-changes: relay recipient (camera/AI)
+{
+    public bool Cancelled = false; // stalker-en-changes: suppress message delivery
+}

--- a/Content.Server/_Stalker_EN/Chat/STVoiceOcclusionSystem.cs
+++ b/Content.Server/_Stalker_EN/Chat/STVoiceOcclusionSystem.cs
@@ -1,0 +1,111 @@
+using System.Text;
+using Content.Server._Stalker.Chat;
+using Content.Server.Chat.Systems;
+using Content.Shared._Stalker.Deafness;
+using Content.Shared.Chat;
+using Content.Shared.Ghost;
+using Content.Shared.Speech;
+using Content.Shared.Speech.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Stalker_EN.Chat;
+
+/// <summary>
+///     Muffles or blocks voice chat when walls occlude the path between speaker and listener.
+///     Also blocks microphone/radio listeners from picking up speech through walls.
+/// </summary>
+public sealed class STVoiceOcclusionSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly OccluderSystem _occluder = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    /// <summary>
+    ///     Maximum distance at which occluded speech is muffled rather than blocked entirely.
+    /// </summary>
+    private const int VoiceMuffledRange = 3;
+
+    /// <summary>
+    ///     Chance each non-whitespace character is kept readable (same scale as whisper: 0.2 = 20%).
+    /// </summary>
+    private const float MuffledReadabilityChance = 0.2f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ActorComponent, STChatMessageOverrideInVoiceRangeEvent>(OnVoiceRange);
+        SubscribeLocalEvent<ActiveListenerComponent, ListenAttemptEvent>(OnListenAttempt);
+    }
+
+    private void OnVoiceRange(Entity<ActorComponent> ent, ref STChatMessageOverrideInVoiceRangeEvent args)
+    {
+        // Don't interfere with non-IC or visual-only channels.
+        if (args.Channel is ChatChannel.LOOC or ChatChannel.Narration
+            or ChatChannel.Damage or ChatChannel.Visual or ChatChannel.Notifications)
+            return;
+
+        // Ghosts and observers always hear everything.
+        if (args.Observer || HasComp<GhostHearingComponent>(ent.Owner))
+            return;
+
+        // Relay recipients (surveillance cameras, AI) — their range was computed from the
+        // relay entity's position, not the viewer's body; occlusion check would be wrong.
+        if (args.HideChatOverride != null)
+            return;
+
+        // Let STDeafSystem handle deaf entities instead of us.
+        if (HasComp<STDeafComponent>(ent.Owner))
+            return;
+
+        // Defensive: negative range means ghost/observer distance — already handled above.
+        if (args.Range < 0)
+            return;
+
+        var sourcePos = _transform.GetMapCoordinates(args.Source);
+        var listenerPos = _transform.GetMapCoordinates(ent.Owner);
+
+        if (_occluder.InRangeUnoccluded(sourcePos, listenerPos, ChatSystem.VoiceRange, ignoreTouching: true))
+            return;
+
+        // Wall detected — muffle if close enough on Local, otherwise block.
+        if (args.Channel == ChatChannel.Local && args.Range <= VoiceMuffledRange)
+        {
+            var obfuscated = ObfuscateMessage(args.Message, MuffledReadabilityChance);
+            args.Message = obfuscated;
+            args.WrappedMessage = Loc.GetString("st-chat-voice-muffled-wrap-message",
+                ("message", FormattedMessage.EscapeText(obfuscated)));
+            return;
+        }
+
+        args.Cancelled = true;
+    }
+
+    /// <summary>
+    ///     Replaces non-whitespace characters with '~' based on a readability chance,
+    ///     mirroring the whisper obfuscation style from <see cref="ChatSystem"/>.
+    /// </summary>
+    private string ObfuscateMessage(string message, float chance)
+    {
+        var sb = new StringBuilder(message);
+        for (var i = 0; i < message.Length; i++)
+        {
+            if (char.IsWhiteSpace(sb[i]))
+                continue;
+
+            if (_random.Prob(1 - chance))
+                sb[i] = '~';
+        }
+        return sb.ToString();
+    }
+
+    private void OnListenAttempt(Entity<ActiveListenerComponent> ent, ref ListenAttemptEvent args)
+    {
+        var sourcePos = _transform.GetMapCoordinates(args.Source);
+        var listenerPos = _transform.GetMapCoordinates(ent.Owner);
+
+        if (!_occluder.InRangeUnoccluded(sourcePos, listenerPos, ent.Comp.Range, ignoreTouching: true))
+            args.Cancel();
+    }
+}

--- a/Resources/Locale/en-US/_Stalker_EN/chat/voice-occlusion.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/chat/voice-occlusion.ftl
@@ -1,0 +1,1 @@
+st-chat-voice-muffled-wrap-message = [font size=11][italic][BubbleHeader]Someone[/BubbleHeader] says, "[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]


### PR DESCRIPTION
## What I changed

Added wall occlusion for voice chat. Speech through walls is now muffled (partially readable) at close range or blocked entirely at longer range. Microphone/radio listeners behind walls are also blocked.

## Changelog

author: @teecoding

- add: Voice chat is now muffled when heard through walls, similar to whispering. At longer range, walls block speech entirely.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
