### PR TITLE
feat: add dedicated log types and reply context to messenger admin logs

### DIFF
--- a/Content.Server/_Stalker_EN/BulletinBoard/STBulletinBoardSystem.cs
+++ b/Content.Server/_Stalker_EN/BulletinBoard/STBulletinBoardSystem.cs
@@ -218,7 +218,7 @@ public sealed class STBulletinBoardSystem : EntitySystem
         storage[offer.Id] = offer;
         _globalOfferIndex[offer.Id] = board.BoardTypeId;
 
-        _adminLogger.Add(LogType.Action, LogImpact.Low,
+        _adminLogger.Add(LogType.STBulletinBoard, LogImpact.Low,
             $"{ToPrettyString(args.Actor):player} posted bulletin board [{board.BoardTypeId}] {post.Category}: " +
             $"desc=\"{description}\"");
 
@@ -248,7 +248,7 @@ public sealed class STBulletinBoardSystem : EntitySystem
         storage.Remove(withdraw.OfferId);
         _globalOfferIndex.Remove(withdraw.OfferId);
 
-        _adminLogger.Add(LogType.Action, LogImpact.Low,
+        _adminLogger.Add(LogType.STBulletinBoard, LogImpact.Low,
             $"{ToPrettyString(args.Actor):player} withdrew bulletin board [{boardTypeId}] offer #{withdraw.OfferId}");
 
         BroadcastUiUpdate(boardTypeId);
@@ -285,7 +285,7 @@ public sealed class STBulletinBoardSystem : EntitySystem
         var draftMessage = STBulletinOffer.FormatRef(draftPrefix, contact.OfferId);
         _messenger.OpenDm(loaderUid, messengerUid.Value, contact.PosterMessengerId, draftMessage);
 
-        _adminLogger.Add(LogType.Action, LogImpact.Low,
+        _adminLogger.Add(LogType.STBulletinBoard, LogImpact.Low,
             $"{ToPrettyString(args.Actor):player} opened DM from bulletin board with: " +
             $"{contact.PosterMessengerId} (offer #{contact.OfferId})");
     }

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -350,16 +350,20 @@ public sealed partial class STMessengerSystem : EntitySystem
             chatMessages.RemoveRange(0, chatMessages.Count - maxMessages);
 
         // Admin log — include anonymous pseudonym so admins can trace abuse
+        var replyInfo = send.ReplyToId is { } rid
+            ? $" (reply to #{rid}: \"{replySnippet}\")"
+            : "";
+
         if (send.IsAnonymous && !isDm)
         {
-            _adminLogger.Add(LogType.PdaMessage, LogImpact.Medium,
+            _adminLogger.Add(LogType.STMessenger, LogImpact.Medium,
                 $"{ToPrettyString(args.Actor):player} sent anonymous message " +
-                $"(as \"{displayName}\") to {chatId}: {content}");
+                $"(as \"{displayName}\") to {chatId}{replyInfo}: {content}");
         }
         else
         {
-            _adminLogger.Add(LogType.PdaMessage, LogImpact.Medium,
-                $"{ToPrettyString(args.Actor):player} sent message to {chatId}: {content}");
+            _adminLogger.Add(LogType.STMessenger, LogImpact.Medium,
+                $"{ToPrettyString(args.Actor):player} sent message to {chatId}{replyInfo}: {content}");
         }
 
         if (isDm)
@@ -496,6 +500,10 @@ public sealed partial class STMessengerSystem : EntitySystem
         AddContactAsync(server.OwnerUserId, server.OwnerCharacterName,
             contactIdentity.UserId, contactIdentity.CharName, factionName);
 
+        _adminLogger.Add(LogType.STMessenger, LogImpact.Low,
+            $"{ToPrettyString(args.Actor):player} added messenger contact " +
+            $"{contactIdentity.CharName} (ID: {add.MessengerId})");
+
         BroadcastUiUpdate();
     }
 
@@ -514,6 +522,10 @@ public sealed partial class STMessengerSystem : EntitySystem
             return;
 
         server.Contacts.Remove(remove.ContactMessengerId);
+
+        _adminLogger.Add(LogType.STMessenger, LogImpact.Low,
+            $"{ToPrettyString(args.Actor):player} removed messenger contact " +
+            $"{contactEntry.CharacterName} (ID: {remove.ContactMessengerId})");
 
         RemoveContactAsync(server.OwnerUserId, server.OwnerCharacterName,
             contactEntry.UserId, contactEntry.CharacterName);

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -484,4 +484,14 @@ public enum LogType
     /// </summary>
     RespawnContainer = 191,
     PdaMessage = 192,
+
+    /// <summary>
+    /// Stalker bulletin board actions (post, withdraw, contact poster).
+    /// </summary>
+    STBulletinBoard = 193,
+
+    /// <summary>
+    /// Stalker PDA messenger actions (send message, add/remove contact).
+    /// </summary>
+    STMessenger = 194,
 }


### PR DESCRIPTION
## What I changed

Added dedicated admin log types for messenger and bulletin board actions, and included reply context in messenger admin logs. Previously these used generic `Chat` log type — now they use specific log types (`MessengerSend`, `MessengerDelete`, `BulletinBoardPost`, `BulletinBoardDelete`) for better filtering. Messenger send logs now also include the message being replied to, if applicable.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
