### PR TITLE
fix: restore SS14DefaultTheme as the default UI theme

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -174,7 +174,7 @@ namespace Content.Client.Entry
             _clientPreferencesManager.Initialize();
             _euiManager.Initialize();
             _voteManager.Initialize();
-            _userInterfaceManager.SetDefaultTheme("STDeepDiveTheme"); // stalker-changes-UI
+            _userInterfaceManager.SetDefaultTheme("SS14DefaultTheme"); // stalker-en-changes
             _documentParsingManager.Initialize();
             _discordAuthManager.Initialize(); // Stalker-Changes-Auth
             _joinQueueManager.Initialize(); // Stalker-Changes - Corvax Queue Adaptation

--- a/Resources/Prototypes/_Stalker_EN/hud.yml
+++ b/Resources/Prototypes/_Stalker_EN/hud.yml
@@ -1,0 +1,5 @@
+- type: hudTheme
+  id: SS14DefaultTheme
+  name: ui-options-hud-theme-default
+  path: Default
+  order: -1


### PR DESCRIPTION
## What I changed

Restored `SS14DefaultTheme` as the default UI theme instead of `STDeepDiveTheme`. Added a HUD theme prototype definition for `SS14DefaultTheme` in `_Stalker_EN/hud.yml`.

## Changelog

author: @teecoding

- fix: Restored the default SS14 UI theme

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
