### PR TITLE
fix(mutants): add missing weight to byurer prototype

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/Mutants/T3/byurer.yml
@@ -66,6 +66,8 @@
     availableModes:
       - FullAuto
     soundGunshot: /Audio/_Stalker/Mutants/wooden_box_breaking.ogg
+  - type: STWeight
+    self: 80
   - type: Butcherable
     spawned:
     - id: MutantPartBurerBrain


### PR DESCRIPTION
## What I changed

Added missing STWeight component to the Byurer (T3 mutant) prototype, setting self weight to 80.

## Changelog

author: @teecoding

- fix: Byurer mutant now has proper weight

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
