### PR TITLE
fix: prevent scope action from appearing when gun is on back

### DIFF
--- a/Content.Shared/_Stalker/Weapon/Scoping/STSharedScopeSystem.cs
+++ b/Content.Shared/_Stalker/Weapon/Scoping/STSharedScopeSystem.cs
@@ -145,6 +145,9 @@ public abstract partial class STSharedScopeSystem : EntitySystem
 
     private void OnGetActions(Entity<ScopeComponent> ent, ref GetItemActionsEvent args)
     {
+        if (!args.InHands)
+            return;
+
         args.AddAction(ref ent.Comp.ScopingToggleActionEntity, ent.Comp.ScopingToggleAction);
     }
 


### PR DESCRIPTION
## What I changed
Fixed the scope action showing up when a gun is on your back slot. Now the scope toggle only appears when you're actually holding the weapon.

## Changelog
author: @teecoding

- fix: Scope action no longer haunts your action bar when your gun is chilling on your back

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
