### PR TITLE
fix: skip program-container instead of blacklisting CartridgeComponent in stash repository

### DIFF
--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -12,7 +12,6 @@ using Content.Shared._Stalker.Weight;
 using Content.Shared.Actions;
 using Content.Shared.Body.Organ;
 using Content.Shared.Body.Part;
-using Content.Shared.CartridgeLoader;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Database;
@@ -692,7 +691,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
 
         foreach (var container in managerComponent.Containers)
         {
-            if (container.Key == "toggleable-clothing") // We don't need anything from this container
+            if (container.Key == "toggleable-clothing" || container.Key == "program-container") // We don't need anything from these containers
                 continue;
             foreach (var element in container.Value.ContainedEntities)
             {
@@ -703,7 +702,6 @@ public sealed class StalkerRepositorySystem : EntitySystem
                     HasComp<EntityTargetActionComponent>(element) ||
                     HasComp<SubdermalImplantComponent>(element) ||
                     HasComp<BodyPartComponent>(element) ||
-                    HasComp<CartridgeComponent>(element) ||
                     HasComp<VirtualItemComponent>(element) ||
                     HasComp<MindContainerComponent>(element) || // Do not insert alive objects(mice, etc.)
                     HasComp<StatusEffectComponent>(element) || // Don't look at status effect entities
@@ -767,7 +765,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
 
         foreach (var container in containerMan.Containers)
         {
-            if (container.Key == "toggleable-clothing") // We don't need to add something from this container
+            if (container.Key == "toggleable-clothing" || container.Key == "program-container") // We don't need to add something from these containers
                 continue;
 
             foreach (var item in container.Value.ContainedEntities)
@@ -777,8 +775,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
                 // another large blacklist
                 if (HasComp<SolutionComponent>(item) || // Do not insert solutions
                     HasComp<InstantActionComponent>(item) || // Do not insert actions
-                    HasComp<CartridgeComponent>(item) && !_tags.HasTag(item, "Dogtag") ||
-                    HasComp<BallisticAmmoProviderComponent>(playerItem) && _tags.HasTag(item, "Cartridge") || // Do not insert program cartridges
+                    HasComp<BallisticAmmoProviderComponent>(playerItem) && _tags.HasTag(item, "Cartridge") || // Do not insert ammo cartridges
                     HasComp<UnremoveableComponent>(item) ||
                     HasComp<SelfUnremovableClothingComponent>(item))
                     continue;


### PR DESCRIPTION
## What I changed
Fixed stash repository filtering PDA cartridges by skipping the program-container entirely instead of blacklisting CartridgeComponent. This also fixes dogtags needing a special exception since they're no longer caught by the cartridge check.

## Changelog
author: @teecoding

- fix: Your PDA programs no longer mysteriously vanish when using the stash

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
