### PR TITLE
fix: use deterministic hash in loadout identifiers and add ammo-aware stash matching

### DIFF
--- a/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
+++ b/Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs
@@ -949,7 +949,11 @@ public sealed class LoadoutSystem : EntitySystem
         HashSet<EntityUid> consumedExistingItems)
     {
         // Find the item in stash
-        var stashItem = FindItemInStash(slotItem.Identifier, slotItem.PrototypeId, stashLookup);
+        var stashItem = FindItemInStash(
+            slotItem.Identifier,
+            slotItem.PrototypeId,
+            stashLookup,
+            slotItem.StorageData as IItemStalkerStorage);
         if (stashItem == null)
             return false;
 
@@ -1035,7 +1039,11 @@ public sealed class LoadoutSystem : EntitySystem
             }
 
             // Find the item in stash
-            var stashItem = FindItemInStash(nestedItem.Identifier, nestedItem.PrototypeId, stashLookup);
+            var stashItem = FindItemInStash(
+                nestedItem.Identifier,
+                nestedItem.PrototypeId,
+                stashLookup,
+                nestedItem.StorageData as IItemStalkerStorage);
             if (stashItem == null)
                 continue;
 
@@ -1424,7 +1432,16 @@ public sealed class LoadoutSystem : EntitySystem
         return null;
     }
 
-    private RepositoryItemInfo? FindItemInStash(string identifier, string prototypeId, StashLookup lookup)
+    /// <summary>
+    /// Finds a stash item by exact identifier match, falling back to prototype-based matching.
+    /// When <paramref name="loadoutStorageData"/> is an <see cref="AmmoContainerStalker"/>,
+    /// the fallback prefers magazines with matching ammo composition over just the fullest.
+    /// </summary>
+    private RepositoryItemInfo? FindItemInStash(
+        string identifier,
+        string prototypeId,
+        StashLookup lookup,
+        IItemStalkerStorage? loadoutStorageData = null)
     {
         // Try exact identifier match first - iterate through list
         if (lookup.ByIdentifier.TryGetValue(identifier, out var identList))
@@ -1438,9 +1455,13 @@ public sealed class LoadoutSystem : EntitySystem
 
         // Fallback to prototype match - return ANY item with count > 0
         // This handles state-based identifier mismatches (stack counts, ammo counts, charges)
-        // For magazines, prefer the fullest one (highest AmmoCount)
         if (lookup.ByPrototype.TryGetValue(prototypeId, out var protoList))
         {
+            // For ammo containers: prefer matching ammo composition over just fullest magazine
+            if (loadoutStorageData is AmmoContainerStalker loadoutAmmo)
+                return FindBestAmmoMatch(protoList, loadoutAmmo);
+
+            // Generic fallback: for magazines without loadout ammo data, prefer fullest
             RepositoryItemInfo? best = null;
             var bestAmmo = -1;
             RepositoryItemInfo? fallback = null;
@@ -1468,6 +1489,59 @@ public sealed class LoadoutSystem : EntitySystem
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Finds the best ammo container match from stash using preference tiers:
+    /// 1. Exact EntProtoIds match (same ammo composition and order)
+    /// 2. Same set of unique ammo types (handles partial magazines)
+    /// 3. Fullest magazine (last resort)
+    /// </summary>
+    private static RepositoryItemInfo? FindBestAmmoMatch(
+        List<RepositoryItemInfo> protoList,
+        AmmoContainerStalker loadoutAmmo)
+    {
+        RepositoryItemInfo? exactMatch = null;
+        RepositoryItemInfo? sameTypesMatch = null;
+        RepositoryItemInfo? fullestMatch = null;
+        var fullestAmmo = -1;
+
+        var loadoutAmmoTypes = loadoutAmmo.EntProtoIds.ToHashSet();
+
+        for (var i = protoList.Count - 1; i >= 0; i--)
+        {
+            if (protoList[i].Count <= 0)
+                continue;
+
+            if (protoList[i].SStorageData is not AmmoContainerStalker stashAmmo)
+                continue;
+
+            // Tier 1: Exact EntProtoIds match
+            if (exactMatch == null &&
+                stashAmmo.EntProtoIds.SequenceEqual(loadoutAmmo.EntProtoIds))
+            {
+                exactMatch = protoList[i];
+                break; // Can't do better than exact match
+            }
+
+            // Tier 2: Same set of unique ammo types (order/count may differ)
+            // Use IsSupersetOf with count check to avoid allocating a HashSet per candidate
+            if (sameTypesMatch == null &&
+                stashAmmo.EntProtoIds.Count == loadoutAmmoTypes.Count &&
+                loadoutAmmoTypes.IsSupersetOf(stashAmmo.EntProtoIds))
+            {
+                sameTypesMatch = protoList[i];
+            }
+
+            // Tier 3: Track fullest magazine as last resort
+            if (stashAmmo.AmmoCount > fullestAmmo)
+            {
+                fullestAmmo = stashAmmo.AmmoCount;
+                fullestMatch = protoList[i];
+            }
+        }
+
+        return exactMatch ?? sameTypesMatch ?? fullestMatch;
     }
 
     private void RemoveFromStash(

--- a/Content.Shared/_Stalker/Storage/StorageItems.cs
+++ b/Content.Shared/_Stalker/Storage/StorageItems.cs
@@ -11,6 +11,21 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared._Stalker.Storage;
 
+// stalker-en-changes - deterministic hash for stable identifiers across process restarts
+internal static class StalkerIdentifierHelper
+{
+    internal static int DeterministicHash(string input)
+    {
+        unchecked
+        {
+            var hash = 5381;
+            foreach (var c in input)
+                hash = (hash << 5) + hash + c;
+            return hash;
+        }
+    }
+}
+
 public interface IItemStalkerStorage
 {
     string ClassType { get; set; }
@@ -90,9 +105,9 @@ public class SimpleItemStalker : IItemStalkerStorage
     {
         var id = "S_" + PrototypeName;
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 
@@ -126,7 +141,7 @@ public class PaperItemStalker : IItemStalkerStorage
     {
         if (input == null)
             return "";
-        return "" + input.GetHashCode();
+        return "" + StalkerIdentifierHelper.DeterministicHash(input); // stalker-en-changes
     }
 
     public string Identifier()
@@ -145,9 +160,9 @@ public class PaperItemStalker : IItemStalkerStorage
 
         var Return = "P_" + PrototypeName + "_HASHTEXT=" + Hash(Content) + "_CS=" + ContentSize + "_SS=" + StampState + "_STAMPS=" + StampsDataString;
         if (!string.IsNullOrEmpty(EngravedMessage))
-            Return += "_ENG=" + EngravedMessage.GetHashCode();
+            Return += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            Return += "_LBL=" + CurrentLabel.GetHashCode();
+            Return += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
 
         SavedIdentifier = Return;
 
@@ -200,9 +215,9 @@ public sealed class BatteryItemStalker : IItemStalkerStorage
     {
         var id = PrototypeName + "_" + CurrentCharge;
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 
@@ -237,9 +252,9 @@ public sealed class SolutionItemStalker : IItemStalkerStorage
         var contentsString = string.Join(", ", Contents.Select(kv => $"{kv.Key}: [{string.Join(", ", kv.Value)}]"));
         var id = $"{PrototypeName}_{contentsString}_{Volume}";
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 
@@ -266,9 +281,9 @@ public class StackItemStalker : IItemStalkerStorage
     {
         var id = PrototypeName + "_" + StackCount;
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 }
@@ -306,14 +321,15 @@ public sealed class AmmoContainerStalker : IItemStalkerStorage
     public string Identifier()
     {
         // Include hash of EntProtoIds to distinguish magazines with different ammo compositions
+        // stalker-en-changes - use deterministic hash for stable identifiers across process restarts
         var entProtosHash = EntProtoIds.Count > 0
-            ? string.Join(",", EntProtoIds).GetHashCode()
+            ? StalkerIdentifierHelper.DeterministicHash(string.Join(",", EntProtoIds))
             : 0;
         var id = $"{PrototypeName}_{AmmoPrototypeName}_{AmmoCount}_{entProtosHash}";
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 }
@@ -338,9 +354,9 @@ public sealed class AmmoItemStalker : IItemStalkerStorage
     {
         var id = $"{PrototypeName}_{Exhausted}";
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 }
@@ -366,9 +382,9 @@ public sealed class CrayonItemStalker : IItemStalkerStorage
     {
         var id = $"{PrototypeName}_{Charges}";
         if (!string.IsNullOrEmpty(EngravedMessage))
-            id += "_ENG=" + EngravedMessage.GetHashCode();
+            id += "_ENG=" + StalkerIdentifierHelper.DeterministicHash(EngravedMessage); // stalker-en-changes
         if (!string.IsNullOrEmpty(CurrentLabel))
-            id += "_LBL=" + CurrentLabel.GetHashCode();
+            id += "_LBL=" + StalkerIdentifierHelper.DeterministicHash(CurrentLabel); // stalker-en-changes
         return id;
     }
 }


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Fixed loadout item matching to use deterministic hashing instead of `string.GetHashCode()` for storage item identifiers. `GetHashCode()` is not guaranteed to be stable across process restarts, which caused loadout items to fail matching with their stash counterparts after a server restart.

Also added ammo-aware stash matching for magazines. When restoring a loadout, the system now prefers magazines with matching ammo composition using a tiered fallback:
1. Exact ammo sequence match
2. Same set of ammo types
3. Fullest magazine (last resort)

**Files changed:**
- `Content.Shared/_Stalker/Storage/StorageItems.cs` - Replaced all `GetHashCode()` calls in `Identifier()` methods with a deterministic DJB2 hash via `StalkerIdentifierHelper`
- `Content.Server/_Stalker_EN/Loadout/LoadoutSystem.cs` - `FindItemInStash` now accepts loadout storage data and uses `FindBestAmmoMatch` for ammo containers

## Changelog

author: @teecoding

- fix: Your stash items no longer get identity crises after a server restart. Loadouts actually find the right items now
- tweak: Magazines with matching ammo types are now preferred when restoring loadouts. 

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
