### PR TITLE
fix: use RichTextLabel for PDA news comments to enable text wrapping

### DIFF
--- a/Content.Client/_Stalker_EN/News/STNewsUiFragment.xaml.cs
+++ b/Content.Client/_Stalker_EN/News/STNewsUiFragment.xaml.cs
@@ -529,13 +529,14 @@ public sealed partial class STNewsUiFragment : BoxContainer, INewsLinkClickHandl
 
         vbox.AddChild(header);
 
-        var contentLabel = new Label
+        var contentLabel = new RichTextLabel
         {
-            Text = comment.Content,
             HorizontalExpand = true,
-            ClipText = false,
             Margin = new Thickness(4, 2, 0, 0),
         };
+        var contentMsg = new FormattedMessage();
+        contentMsg.AddText(comment.Content);
+        contentLabel.SetMessage(contentMsg);
         vbox.AddChild(contentLabel);
 
         var separator = new HSeparator


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Switched PDA news comments from `Label` to `RichTextLabel` so long comments actually wrap instead of running off the edge of the screen.

## Changelog
author: @teecoding

- fix: PDA news comments no longer escape containment and clip off screen. Text wrapping works now, your manifestos are fully readable.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
