### PR TITLE
feat: prioritize bolt bags when stowing bolts via quick equip

### DIFF
--- a/Content.Shared/_Stalker_EN/QuickEquipBolt/STQuickEquipBoltSystem.cs
+++ b/Content.Shared/_Stalker_EN/QuickEquipBolt/STQuickEquipBoltSystem.cs
@@ -4,7 +4,10 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Tag;
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
@@ -24,6 +27,7 @@ public sealed class STQuickEquipBoltSystem : EntitySystem
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
 
     private static readonly ProtoId<TagPrototype> BoltTag = "STBolt";
 
@@ -67,6 +71,16 @@ public sealed class STQuickEquipBoltSystem : EntitySystem
         if (!_actionBlocker.CanInteract(uid, null))
             return;
 
+        // If holding a bolt, try to stow it back into inventory storage.
+        if (_hands.TryGetActiveItem((uid, hands), out var activeItem) && _tag.HasTag(activeItem.Value, BoltTag))
+        {
+            if (TryStowBolt(uid, activeItem.Value))
+                return;
+
+            _popup.PopupClient(Loc.GetString("st-quick-equip-bolt-no-storage"), uid, uid);
+            return;
+        }
+
         if (!_hands.TryGetEmptyHand((uid, hands), out _))
         {
             _popup.PopupClient(Loc.GetString("st-quick-equip-bolt-hands-full"), uid, uid);
@@ -83,10 +97,94 @@ public sealed class STQuickEquipBoltSystem : EntitySystem
     }
 
     /// <summary>
+    /// Tries to insert a bolt from the player's hand into inventory storage.
+    /// Prioritizes bolt bags (storages whitelisted for STBolt) before falling back to any compatible storage.
+    /// </summary>
+    private bool TryStowBolt(EntityUid uid, EntityUid bolt)
+    {
+        return TryStowBoltPass(uid, bolt, boltBagOnly: true)
+            || TryStowBoltPass(uid, bolt, boltBagOnly: false);
+    }
+
+    /// <summary>
+    /// Single pass of the stow search across all inventory slots.
+    /// When <paramref name="boltBagOnly"/> is true, only bolt bags are considered.
+    /// </summary>
+    private bool TryStowBoltPass(EntityUid uid, EntityUid bolt, bool boltBagOnly)
+    {
+        if (!_inventory.TryGetSlots(uid, out var slotDefs))
+            return false;
+
+        foreach (var slotName in SlotPriority)
+        {
+            if (_inventory.TryGetSlotEntity(uid, slotName, out var slotEntity)
+                && TryInsertBoltIntoStorage(slotEntity.Value, bolt, uid, boltBagOnly))
+            {
+                return true;
+            }
+        }
+
+        foreach (var slotDef in slotDefs)
+        {
+            if (PrioritySlotSet.Contains(slotDef.Name))
+                continue;
+
+            if (_inventory.TryGetSlotEntity(uid, slotDef.Name, out var slotEntity)
+                && TryInsertBoltIntoStorage(slotEntity.Value, bolt, uid, boltBagOnly))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a storage entity is a bolt bag (its whitelist contains the STBolt tag).
+    /// </summary>
+    private bool IsBoltBag(StorageComponent storage)
+    {
+        return storage.Whitelist?.Tags?.Contains(BoltTag) == true;
+    }
+
+    /// <summary>
+    /// Tries to insert a bolt into the given entity's storage, or recursively into nested storages.
+    /// When <paramref name="boltBagOnly"/> is true, only storages identified as bolt bags are considered.
+    /// </summary>
+    private bool TryInsertBoltIntoStorage(EntityUid storageEntity, EntityUid bolt, EntityUid user,
+        bool boltBagOnly, int depth = 0)
+    {
+        if (depth >= MaxSearchDepth)
+            return false;
+
+        if (TryComp<StorageComponent>(storageEntity, out var storage)
+            && (!boltBagOnly || IsBoltBag(storage))
+            && _storage.CanInsert(storageEntity, bolt, out _, storage)
+            && _storage.Insert(storageEntity, bolt, out _, user, storage, playSound: true))
+        {
+            return true;
+        }
+
+        if (!TryComp<ContainerManagerComponent>(storageEntity, out var containerManager))
+            return false;
+
+        foreach (var container in _container.GetAllContainers(storageEntity, containerManager))
+        {
+            foreach (var contained in container.ContainedEntities)
+            {
+                if (TryInsertBoltIntoStorage(contained, bolt, user, boltBagOnly, depth + 1))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Searches the player's inventory slots and their nested containers for an entity with the STBolt tag.
     /// Priority slots are checked first, then remaining slots.
     /// </summary>
-    private bool TryFindBolt(EntityUid uid, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EntityUid? found)
+    private bool TryFindBolt(EntityUid uid, [NotNullWhen(true)] out EntityUid? found)
     {
         found = null;
 
@@ -120,7 +218,10 @@ public sealed class STQuickEquipBoltSystem : EntitySystem
     /// <summary>
     /// Checks if the entity itself has the STBolt tag, or recursively searches its containers.
     /// </summary>
-    private bool TryFindBoltInEntity(EntityUid entity, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out EntityUid? found, int depth)
+    private bool TryFindBoltInEntity(
+        EntityUid entity,
+        [NotNullWhen(true)] out EntityUid? found,
+        int depth)
     {
         found = null;
 

--- a/Resources/Locale/en-US/_Stalker_EN/quick-equip-bolt.ftl
+++ b/Resources/Locale/en-US/_Stalker_EN/quick-equip-bolt.ftl
@@ -1,2 +1,3 @@
 st-quick-equip-bolt-hands-full = Your hands are full!
 st-quick-equip-bolt-none-found = No bolts found!
+st-quick-equip-bolt-no-storage = No place to store bolt!


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Quick equip bolt keybind now works both ways. If you're holding a bolt, it stows it back into your inventory, prioritizing bolt bags first before falling back to any compatible storage. Searches nested containers recursively.

Also cleaned up some fully qualified `NotNullWhen` attributes to use the imported version.

## Changelog
author: @teecoding

- add: Pressing the quick bolt key while holding a bolt now puts it back in your inventory. Bolt bags get priority so your precious bolts stay organized.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
