### PR TITLE
fix: restore messenger send button and add per-channel anonymous control

### DIFF
--- a/Content.Client/_Stalker_EN/PdaMessenger/STMessengerComposePage.xaml
+++ b/Content.Client/_Stalker_EN/PdaMessenger/STMessengerComposePage.xaml
@@ -22,7 +22,7 @@
     </BoxContainer>
 
     <!-- Anonymous toggle (channels only) -->
-    <!-- <CheckBox Name="AnonymousToggle" Text="{Loc 'st-messenger-compose-anonymous'}" Margin="0 2 0 2"/> -->
+    <CheckBox Name="AnonymousToggle" Text="{Loc 'st-messenger-compose-anonymous'}" Margin="0 2 0 2"/>
 
     <!-- Reply context (optional) -->
     <PanelContainer Name="ReplyContext" Visible="False" Margin="0 0 0 4">

--- a/Content.Client/_Stalker_EN/PdaMessenger/STMessengerComposePage.xaml.cs
+++ b/Content.Client/_Stalker_EN/PdaMessenger/STMessengerComposePage.xaml.cs
@@ -46,7 +46,7 @@ public sealed partial class STMessengerComposePage : BoxContainer
             var content = Rope.Collapse(ContentInput.TextRope).Trim();
             if (!string.IsNullOrEmpty(content))
             {
-                //OnSend?.Invoke(_chatId, content, AnonymousToggle.Pressed);
+                OnSend?.Invoke(_chatId, content, AnonymousToggle.Pressed);
                 ContentInput.TextRope = Rope.Leaf.Empty;
             }
         };
@@ -73,8 +73,7 @@ public sealed partial class STMessengerComposePage : BoxContainer
         _chatId = chatId;
         _isDmChat = chatId.StartsWith(STMessengerChat.DmChatPrefix, StringComparison.Ordinal);
         ContentInput.TextRope = initialContent is not null ? new Rope.Leaf(initialContent) : Rope.Leaf.Empty;
-        //AnonymousToggle.Pressed = false;
-        //AnonymousToggle.Visible = !_isDmChat;
+        AnonymousToggle.Pressed = false;
 
         _maxLength = _config.GetCVar(STCCVars.MessengerMaxMessageLength);
         var initialLength = initialContent?.Length ?? 0;
@@ -88,12 +87,13 @@ public sealed partial class STMessengerComposePage : BoxContainer
         {
             // Use the display name (character name) if available, otherwise fall back to messenger ID from chat ID
             RecipientLabel.Text = displayName ?? chatId[STMessengerChat.DmChatPrefix.Length..];
+            AnonymousToggle.Visible = false;
         }
         else
         {
-            RecipientLabel.Text = _protoManager.TryIndex<STMessengerChannelPrototype>(chatId, out var proto)
-                ? Loc.GetString(proto.Name)
-                : chatId;
+            var hasProto = _protoManager.TryIndex<STMessengerChannelPrototype>(chatId, out var proto);
+            RecipientLabel.Text = hasProto ? Loc.GetString(proto!.Name) : chatId;
+            AnonymousToggle.Visible = hasProto && proto!.AllowAnonymous;
         }
 
         if (replyToId is not null && replySnippet is not null)

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -281,8 +281,11 @@ public sealed partial class STMessengerSystem : EntitySystem
         var chatId = send.TargetChatId;
         var isDm = chatId.StartsWith(STMessengerChat.DmChatPrefix, StringComparison.Ordinal);
 
+        // Effective anonymous flag: only allowed for non-DM channels that explicitly permit it
+        var isAnonymous = send.IsAnonymous && !isDm;
+
         // Determine display name: anonymous pseudonym for channels, real name for DMs
-        var displayName = (send.IsAnonymous && !isDm)
+        var displayName = isAnonymous
             ? GetOrCreatePseudonym(senderKey)
             : senderName;
 
@@ -325,8 +328,23 @@ public sealed partial class STMessengerSystem : EntitySystem
             if (!_protoManager.TryIndex(chatId, out channelProto))
                 return;
 
+            // Re-resolve the holder's band before access check (band may have changed)
+            if (TryComp<TransformComponent>(loaderUid, out var pdaXform))
+            {
+                var holder = pdaXform.ParentUid;
+                if (holder.IsValid())
+                    server.OwnerBand = ResolveMobBand(holder);
+            }
+
             if (!HasChannelAccess(channelProto, server))
                 return;
+
+            // Enforce per-channel anonymous setting
+            if (isAnonymous && !channelProto.AllowAnonymous)
+            {
+                isAnonymous = false;
+                displayName = senderName;
+            }
 
             storageKey = chatId;
             chatMessages = _channelChats.GetOrNew(storageKey);
@@ -337,10 +355,10 @@ public sealed partial class STMessengerSystem : EntitySystem
         var msgId = ++_nextMessageId[storageKey];
 
         // Resolve faction and rank for non-anonymous messages; null hides them on anonymous messages
-        string? senderFaction = !send.IsAnonymous
+        string? senderFaction = !isAnonymous
             ? ResolveContactFaction(senderKey)
             : null;
-        string? senderRankIcon = !send.IsAnonymous
+        string? senderRankIcon = !isAnonymous
             ? ResolveContactRankIcon(senderKey)
             : null;
 
@@ -367,7 +385,7 @@ public sealed partial class STMessengerSystem : EntitySystem
             ? $" (reply to #{rid}: \"{replySnippet}\")"
             : "";
 
-        if (send.IsAnonymous && !isDm)
+        if (isAnonymous)
         {
             _adminLogger.Add(LogType.STMessenger, LogImpact.Medium,
                 $"{ToPrettyString(args.Actor):player} sent anonymous message " +
@@ -468,6 +486,14 @@ public sealed partial class STMessengerSystem : EntitySystem
         {
             if (!TryComp<STMessengerServerComponent>(cartridgeUid, out var server))
                 continue;
+
+            // Re-resolve the holder's band before access check (band may have changed)
+            if (TryComp<TransformComponent>(pdaUid, out var pdaXform))
+            {
+                var holder = pdaXform.ParentUid;
+                if (holder.IsValid())
+                    server.OwnerBand = ResolveMobBand(holder);
+            }
 
             if (!HasChannelAccess(channelProto, server))
                 continue;

--- a/Content.Shared/_Stalker_EN/PdaMessenger/STMessengerChannelPrototype.cs
+++ b/Content.Shared/_Stalker_EN/PdaMessenger/STMessengerChannelPrototype.cs
@@ -41,6 +41,12 @@ public sealed class STMessengerChannelPrototype : IPrototype
     public List<ProtoId<STBandPrototype>> RequiredBands { get; } = new();
 
     /// <summary>
+    /// Whether users can send anonymous messages in this channel.
+    /// </summary>
+    [DataField]
+    public bool AllowAnonymous { get; } = false;
+
+    /// <summary>
     /// Whether messages in this channel are forwarded to the Discord webhook.
     /// </summary>
     [DataField]


### PR DESCRIPTION
## What I changed

- Restored the send button in the messenger compose page (was broken due to commented-out anonymous toggle wiring)
- Added per-channel `AllowAnonymous` field to `STMessengerChannelPrototype` so each channel controls whether anonymous posting is allowed
- Anonymous checkbox now only shows on channels that have `allowAnonymous: true`, and is hidden for DMs
- Server enforces the per-channel anonymous setting even if the client sends the flag
- Re-resolves the holder's band before channel access checks on both send and notify paths (fixes stale band after faction changes)

## Changelog

author: @teecoding

- fix: Messenger send button works again (whoops)
- fix: Anonymous toggle no longer shows up in DMs where it did nothing anyway
- add: Messenger channels can now be configured to allow or block anonymous messages
- tweak: No more hiding behind anonymous messages in channels.
- fix: Changing factions mid-round no longer locks you out of your new faction's messenger channels

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
