### PR TITLE
fix: network RankName field to prevent rank flickering on examine

### DIFF
--- a/Content.Shared/_Stalker_EN/CharacterRank/STCharacterRankComponent.cs
+++ b/Content.Shared/_Stalker_EN/CharacterRank/STCharacterRankComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class STCharacterRankComponent : Component
     /// <summary>
     /// Localization key for the rank's display name. Server-only to avoid dirtying on every flush.
     /// </summary>
-    [DataField] // We should network this so it stops flickering on examine
+    [DataField, AutoNetworkedField]
     public LocId RankName = "st-rank-novice";
 
     /// <summary>


### PR DESCRIPTION
## What I changed

Network the RankName field on STCharacterRankComponent so the client has the correct rank name immediately instead of flickering on examine.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/629 

## Changelog

author: @teecoding

- fix: Rank name no longer flickers when examining a player

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
