### PR TITLE
fix: re-apply saved HUD theme after SetDefaultTheme override

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -175,6 +175,10 @@ namespace Content.Client.Entry
             _euiManager.Initialize();
             _voteManager.Initialize();
             _userInterfaceManager.SetDefaultTheme("STClassicTheme"); // stalker-en-changes
+            // Re-apply user's saved theme preference (SetDefaultTheme overrides it)
+            var savedTheme = _configManager.GetCVar(CVars.InterfaceTheme);
+            if (!string.IsNullOrEmpty(savedTheme))
+                _userInterfaceManager.SetActiveTheme(savedTheme);
             _documentParsingManager.Initialize();
             _discordAuthManager.Initialize(); // Stalker-Changes-Auth
             _joinQueueManager.Initialize(); // Stalker-Changes - Corvax Queue Adaptation


### PR DESCRIPTION
## What I changed

- Re-apply the player's saved HUD theme after `SetDefaultTheme` overrides it on startup, so custom theme preferences are preserved.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/630

## Changelog

author: @teecoding

- fix: Your HUD theme preference no longer resets every time you join the server

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
