### PR TITLE
fix: prevent minds attaching to ghost observers on rejoin (#552)

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Content.Shared.Ghost; // stalker-en-changes: ghost check on reconnect
 using Robust.Shared.Map; // stalker-changes: nullspace check on reconnect
 using Robust.Shared.Utility;
 
@@ -97,16 +98,22 @@ namespace Content.Server.GameTicking
                     }
 
                     // stalker-changes-start: prevent reattaching to entities in nullspace (causes black screen)
+                    // stalker-en-changes-start: also prevent reattaching to ghost entities after body deletion
                     if (mind.CurrentEntity == null || Deleted(mind.CurrentEntity)
-                        || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace)
+                        || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace
+                        || (mind.VisitingEntity == null && HasComp<GhostComponent>(mind.CurrentEntity.Value)))
+                    // stalker-en-changes-end
                     // stalker-changes-end
                     {
-                        DebugTools.Assert(mind.CurrentEntity == null || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace, "a mind's current entity was deleted without updating the mind"); // stalker-changes: allow nullspace assert
+                        DebugTools.Assert(mind.CurrentEntity == null
+                            || Transform(mind.CurrentEntity.Value).MapID == MapId.Nullspace
+                            || HasComp<GhostComponent>(mind.CurrentEntity.Value),
+                            "a mind's current entity was deleted without updating the mind"); // stalker-en-changes: allow ghost assert
 
-                        // This player is joining the game with an existing mind, but the mind has no entity.
-                        // Their entity was probably deleted sometime while they were disconnected, or they were an observer.
-                        // Instead of allowing them to spawn in, we will dump and their existing mind in an observer ghost.
-                        SpawnObserverWaitDb();
+                        // This player is joining the game with an existing mind, but the mind has no usable entity.
+                        // Their entity was probably deleted while they were disconnected, or they were left as a ghost.
+                        // stalker-en-changes: Respawn the player instead of creating another observer ghost.
+                        RespawnWaitDb();
                     }
                     else
                     {
@@ -118,7 +125,7 @@ namespace Content.Server.GameTicking
                         {
                             Log.Error(
                                 $"Failed to attach player {session} with mind {ToPrettyString(mindId)} to its current entity {ToPrettyString(mind.CurrentEntity)}");
-                            SpawnObserverWaitDb();
+                            RespawnWaitDb(); // stalker-en-changes: respawn instead of observer
                         }
                     }
 
@@ -171,6 +178,23 @@ namespace Content.Server.GameTicking
 
                 JoinAsObserver(session);
             }
+
+            // stalker-en-changes-start: respawn player instead of creating observer ghost
+            async void RespawnWaitDb()
+            {
+                try
+                {
+                    await _userDb.WaitLoadComplete(session);
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.Debug($"Database load cancelled while waiting to respawn {session}");
+                    return;
+                }
+
+                Respawn(session);
+            }
+            // stalker-en-changes-end
 
             async void AddPlayerToDb(Guid id)
             {


### PR DESCRIPTION
## What I changed

- Reconnecting players who were left as ghosts (e.g. body deleted while offline) now respawn instead of getting stuck as a ghost.

- Closes https://github.com/coolmankid12345/stalker-14-EN/issues/552

## Changelog

author: @teecoding

- fix: Reconnecting after your body was deleted no longer traps you as a ghost

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
