### PR TITLE
Adds t2 suppressors to CS and kesha

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
@@ -406,6 +406,10 @@
       STModuleSilencerSMGT1: 600
       STModuleSniperSightT1: 600
       STModuleSilencerSniperT1: 600
+      STModuleSilencerRiflesT2Ru: 2800
+      STModuleSilencerRiflesT2Nato: 2800
+      STModuleSilencerSniperT2: 2800
+      STModuleSilencerSMGT2: 2800
 
   - name: shop-category-customization
     priority: 12

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/kesha.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/kesha.yml
@@ -345,3 +345,7 @@
         STModuleSilencerSMGT1: 1600
         STModuleSniperSightT1: 1600
         STModuleSilencerSniperT1: 1400
+        STModuleSilencerRiflesT2Ru: 4600
+        STModuleSilencerRiflesT2Nato: 4600
+        STModuleSilencerSniperT2: 4600
+        STModuleSilencerSMGT2: 4800


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Does what the title says. The t1 suppressors reduce distant gunshot distance to 40% while t2 suppressors reduce it to 20%. CS gets it because they are secretive so its fitting and kesha gets it because idk it seems fitting enough. This should be more then balanced especially considering before even t1 silencers would TOTALLY remove the distant sound but now it actually matters.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @dallaszzz

- add: T2 suppressors can now be bought from kesha and CS

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
