### PR TITLE
Stops mutant parts form being in crafter bags **balance discussion**

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
@@ -22,7 +22,8 @@
     blacklist:
       tags:
       - STArtifact
-    whitelist:
+      - Khabar #stalker-en change stops monster parts counting as material Probably..
+    whitelist: 
       components:
         - Material
   - type: Item


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
 Hopefully stops mutant parts from being put in craft bags by blacklisting their tag?
## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @thewizard

- fix: Removes craft bags from being used to hold things they probably shouldnt

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [ ] Yes, I ran my code and tested that the changes worked
- [ ] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
