### PR TITLE
fix: clear buyback on UI close and disconnect, optimize allocations

### DIFF
--- a/Content.Client/_Stalker/Shop/Ui/ShopBoundUserInterface.cs
+++ b/Content.Client/_Stalker/Shop/Ui/ShopBoundUserInterface.cs
@@ -42,9 +42,11 @@ public sealed class ShopBoundUserInterface : BoundUserInterface
         _menu.OnListingButtonPressed += (_, listing, sell, balance, count) =>
         {
             // stalker-changes-en: route buyback purchases to the dedicated message
-            if (!sell && listing.ID != null && listing.ID.StartsWith("st-buyback-"))
+            if (!sell && listing.ID != null && listing.ID.StartsWith(STBuybackConstants.IdPrefix))
             {
-                var buybackId = listing.ID.Substring("st-buyback-".Length);
+                if (!uint.TryParse(listing.ID.Substring(STBuybackConstants.IdPrefix.Length), out var buybackId))
+                    return;
+
                 SendMessage(new STBuybackPurchaseMessage(buybackId, balance));
                 return;
             }

--- a/Content.Server/_Stalker/Shop/ShopSystem.cs
+++ b/Content.Server/_Stalker/Shop/ShopSystem.cs
@@ -69,6 +69,12 @@ public sealed partial class ShopSystem : SharedShopSystem
         InitializeBulkBuy(); // stalker-14-en
     }
 
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        ShutdownBuyback(); // stalker-changes-en: unsubscribe player status events
+    }
+
     #region UI updates
     private void OnAfterInsert(StorageAfterInsertItemIntoLocationEvent args)
     {
@@ -214,10 +220,18 @@ public sealed partial class ShopSystem : SharedShopSystem
         _sawmill.Debug($"Sent balance to client: {component.CurrentBalance}");
 
         // stalker-changes-en: inject buyback category into the categories sent to client
-        var allCategories = new List<CategoryInfo>(categories);
         var buybackCategory = GetBuybackCategory(user.Value, component);
+        List<CategoryInfo> allCategories;
         if (buybackCategory != null)
+        {
+            allCategories = new List<CategoryInfo>(categories.Count + 1);
+            allCategories.AddRange(categories);
             allCategories.Add(buybackCategory);
+        }
+        else
+        {
+            allCategories = categories;
+        }
 
         var state = new ShopUpdateState(
             money,

--- a/Content.Server/_Stalker_EN/Shop/ShopSystem.Buyback.cs
+++ b/Content.Server/_Stalker_EN/Shop/ShopSystem.Buyback.cs
@@ -4,10 +4,9 @@ using Content.Shared._Stalker_EN.Shop.Buyback;
 using Content.Shared.FixedPoint;
 using Content.Shared.GameTicking;
 using Content.Shared.Store;
+using Robust.Shared.Enums;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
-
 namespace Content.Server._Stalker.Shop;
 
 /// <summary>
@@ -16,15 +15,50 @@ namespace Content.Server._Stalker.Shop;
 /// </summary>
 public sealed partial class ShopSystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
-
-    private const string BuybackIdPrefix = "st-buyback-";
     private const string BuybackCategoryLocId = "st-shop-buyback-category";
+    private const int BuybackCategoryPriority = 999;
 
     private void InitializeBuyback()
     {
         SubscribeLocalEvent<ShopComponent, STBuybackPurchaseMessage>(OnBuybackPurchase);
+        SubscribeLocalEvent<ShopComponent, ShopClosedMessage>(OnBuybackShopClosed);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnBuybackRoundCleanup);
+        _player.PlayerStatusChanged += OnBuybackPlayerStatusChanged;
+    }
+
+    private void ShutdownBuyback()
+    {
+        _player.PlayerStatusChanged -= OnBuybackPlayerStatusChanged;
+    }
+
+    /// <summary>
+    /// Clears this player's buyback entries from the specific shop they closed.
+    /// </summary>
+    private void OnBuybackShopClosed(EntityUid uid, ShopComponent component, ShopClosedMessage msg)
+    {
+        if (msg.Actor is not { Valid: true } buyer)
+            return;
+
+        if (!TryComp<ActorComponent>(buyer, out var actor))
+            return;
+
+        component.BuybackItems.Remove(actor.PlayerSession.UserId);
+    }
+
+    /// <summary>
+    /// Clears a disconnecting player's buyback entries from all shops.
+    /// </summary>
+    private void OnBuybackPlayerStatusChanged(object? sender, SessionStatusEventArgs args)
+    {
+        if (args.NewStatus != SessionStatus.Disconnected)
+            return;
+
+        var userId = args.Session.UserId;
+        var query = EntityQueryEnumerator<ShopComponent>();
+        while (query.MoveNext(out _, out var comp))
+        {
+            comp.BuybackItems.Remove(userId);
+        }
     }
 
     private void AddBuybackEntry(
@@ -49,26 +83,20 @@ public sealed partial class ShopSystem
         }
 
         var buybackPrice = (int) Math.Ceiling(perItemSellPrice * component.BuybackPriceMultiplier);
-        var now = _timing.CurTime;
 
         for (var i = 0; i < count; i++)
         {
-            var entry = new STBuybackEntry(
-                Guid.NewGuid().ToString(),
+            entries.Add(new STBuybackEntry(
+                component.BuybackNextId++,
                 prototypeId,
                 name,
                 description,
                 perItemSellPrice,
-                buybackPrice,
-                now);
-
-            entries.Add(entry);
-
-            while (entries.Count > component.BuybackMaxItems)
-            {
-                entries.RemoveAt(0);
-            }
+                buybackPrice));
         }
+
+        if (entries.Count > component.BuybackMaxItems)
+            entries.RemoveRange(0, entries.Count - component.BuybackMaxItems);
     }
 
     private CategoryInfo? GetBuybackCategory(EntityUid user, ShopComponent component)
@@ -84,7 +112,7 @@ public sealed partial class ShopSystem
         var category = new CategoryInfo
         {
             Name = BuybackCategoryLocId,
-            Priority = 999,
+            Priority = BuybackCategoryPriority,
         };
 
         foreach (var entry in entries)
@@ -103,7 +131,7 @@ public sealed partial class ShopSystem
                 productEvent: null,
                 raiseProductEventOnUser: false,
                 purchaseAmount: 0,
-                id: BuybackIdPrefix + entry.Id,
+                id: STBuybackConstants.IdPrefix + entry.Id,
                 categories: new HashSet<ProtoId<StoreCategoryPrototype>>(),
                 originalCost: new Dictionary<ProtoId<CurrencyPrototype>, FixedPoint2>
                 {
@@ -133,20 +161,20 @@ public sealed partial class ShopSystem
         if (!component.BuybackItems.TryGetValue(userId, out var entries))
             return;
 
-        STBuybackEntry? targetEntry = null;
         var targetIndex = -1;
         for (var i = 0; i < entries.Count; i++)
         {
             if (entries[i].Id == msg.BuybackEntryId)
             {
-                targetEntry = entries[i];
                 targetIndex = i;
                 break;
             }
         }
 
-        if (targetEntry == null || targetIndex < 0)
+        if (targetIndex < 0)
             return;
+
+        var targetEntry = entries[targetIndex];
 
         var balance = GetMoneyFromList(GetContainersElements(buyer), component);
         if (balance < targetEntry.BuybackPrice)
@@ -169,6 +197,7 @@ public sealed partial class ShopSystem
         while (query.MoveNext(out _, out var component))
         {
             component.BuybackItems.Clear();
+            component.BuybackNextId = 0;
         }
     }
 }

--- a/Content.Shared/_Stalker/Shop/ShopComponent.cs
+++ b/Content.Shared/_Stalker/Shop/ShopComponent.cs
@@ -53,5 +53,12 @@ public sealed partial class ShopComponent : Component
     /// Not networked -- only the server needs to know the full buyback state.
     /// The client receives buyback items as a regular shop category.
     /// </summary>
+    [ViewVariables]
     public Dictionary<NetUserId, List<STBuybackEntry>> BuybackItems = new();
+
+    /// <summary>
+    /// Server-only: monotonically increasing counter for buyback entry IDs.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public uint BuybackNextId;
 }

--- a/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackConstants.cs
+++ b/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackConstants.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared._Stalker_EN.Shop.Buyback;
+
+/// <summary>
+/// Shared constants for the buyback system, used by both client and server.
+/// </summary>
+public static class STBuybackConstants
+{
+    /// <summary>
+    /// Prefix prepended to buyback entry IDs in shop listing data.
+    /// </summary>
+    public const string IdPrefix = "st-buyback-";
+}

--- a/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackEntry.cs
+++ b/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackEntry.cs
@@ -7,58 +7,10 @@ namespace Content.Shared._Stalker_EN.Shop.Buyback;
 /// Stored per-player in the shop component's buyback dictionary.
 /// </summary>
 [Serializable, NetSerializable]
-public sealed class STBuybackEntry
-{
-    /// <summary>
-    /// Unique identifier for this buyback entry (GUID).
-    /// </summary>
-    public string Id;
-
-    /// <summary>
-    /// The entity prototype ID of the sold item.
-    /// </summary>
-    public string PrototypeId;
-
-    /// <summary>
-    /// Display name captured at the time of sale.
-    /// </summary>
-    public string Name;
-
-    /// <summary>
-    /// Description captured at the time of sale.
-    /// </summary>
-    public string Description;
-
-    /// <summary>
-    /// The price the player received when selling the item.
-    /// </summary>
-    public int OriginalSellPrice;
-
-    /// <summary>
-    /// The price to repurchase the item (OriginalSellPrice * markup, rounded up).
-    /// </summary>
-    public int BuybackPrice;
-
-    /// <summary>
-    /// Server time when the item was sold.
-    /// </summary>
-    public TimeSpan SoldAt;
-
-    public STBuybackEntry(
-        string id,
-        string prototypeId,
-        string name,
-        string description,
-        int originalSellPrice,
-        int buybackPrice,
-        TimeSpan soldAt)
-    {
-        Id = id;
-        PrototypeId = prototypeId;
-        Name = name;
-        Description = description;
-        OriginalSellPrice = originalSellPrice;
-        BuybackPrice = buybackPrice;
-        SoldAt = soldAt;
-    }
-}
+public readonly record struct STBuybackEntry(
+    uint Id,
+    string PrototypeId,
+    string Name,
+    string Description,
+    int OriginalSellPrice,
+    int BuybackPrice);

--- a/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackPurchaseMessage.cs
+++ b/Content.Shared/_Stalker_EN/Shop/Buyback/STBuybackPurchaseMessage.cs
@@ -12,14 +12,14 @@ public sealed class STBuybackPurchaseMessage : BoundUserInterfaceMessage
     /// <summary>
     /// The unique ID of the buyback entry to repurchase.
     /// </summary>
-    public string BuybackEntryId;
+    public uint BuybackEntryId;
 
     /// <summary>
     /// The client's current balance at time of request.
     /// </summary>
     public int Balance;
 
-    public STBuybackPurchaseMessage(string buybackEntryId, int balance)
+    public STBuybackPurchaseMessage(uint buybackEntryId, int balance)
     {
         BuybackEntryId = buybackEntryId;
         Balance = balance;


### PR DESCRIPTION
## What I changed
Buyback entries are now cleared when a player closes the shop UI or disconnects, preventing stale data from accumulating in memory


## Changelog
author: @teecoding

- fix: Buyback entries are now properly cleared when closing a shop or disconnecting
- tweak: Reduced memory allocations in the shop buyback system

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
