### PR TITLE
Fixes monolith doll

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Mobs/rolesSpawners.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Mobs/rolesSpawners.yml
@@ -435,10 +435,19 @@
     - type: PersonalDamageBlock
     - type: Damageable
       damageContainer: Biological
+      damageModifierSet: Monolith # Stalker EN change
     - type: STAnomalyTipsViewing
     - type: AutoImplant
       implants:
       - STSeraBombImplant
+    - type: IntrinsicRadioReceiver # Stalker EN change start
+    - type: IntrinsicRadioTransmitter
+      channels:
+      - Monolith
+    - type: ActiveRadio
+      channels:
+      - Monolith
+      GlobalReceive: true # Stalker EN change end
 
 - type: entity
   name: кукла СБУ (переименуй меня)


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Fixes the monolith doll that admins can spawn not having radiation/psy protection or the inbuilt radio.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @dallaszzz

- fix: mono doll not having rad/psy protection or monolith radio

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
