### PR TITLE
Fixes being able to put mutant parts into the craftsman bag

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/Belts/crafter_bugs.yml
@@ -22,6 +22,7 @@
     blacklist:
       tags:
       - STArtifact
+      - Khabar
     whitelist:
       components:
         - Material


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Fixes being able to put mutant parts into the craftsman bag, as this was not its intended purpose.
Thanks to THE WIZARD, for informing me of this oversight, so I could get a quick fix in!
## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Roland410

- fix: Fixes being able to put mutant parts into the craftsman bag.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
