### PR TITLE
fix: resolve radar detector container filtering, spawner visibility, and sweep wraparound bugs

### DIFF
--- a/Content.Client/_Stalker_EN/Devices/Radar/UI/RadarControl.cs
+++ b/Content.Client/_Stalker_EN/Devices/Radar/UI/RadarControl.cs
@@ -29,8 +29,6 @@ public sealed class RadarControl : Control
     // Sonar sweep animation
     private const float SweepSpeed = 0.25f; // Rotations per second
     private const float BlipFadeDuration = 2.5f; // Seconds for blip to fully fade
-    private const float SweepHitThreshold = 0.15f; // Radians tolerance for sweep detection
-
     private float _lastSweepAngle;
     private float _sweepStartTime = -1f;  // Sentinel for uninitialized
 
@@ -99,11 +97,8 @@ public sealed class RadarControl : Control
         var currentTime = (float)_timing.CurTime.TotalSeconds;
         var elapsedTime = currentTime - _sweepStartTime;
 
-        // Rotating sweep: continuous rotation around full circle
+        // Rotating sweep: continuous rotation around full circle (0 to 2*PI)
         var sweepAngle = (elapsedTime * SweepSpeed * MathF.PI * 2) % (MathF.PI * 2);
-        // Adjust to -PI to PI range for comparison with blip angles
-        if (sweepAngle > MathF.PI)
-            sweepAngle -= MathF.PI * 2;
 
         // Build set of current blip IDs for cleanup
         _currentIds.Clear();
@@ -159,27 +154,29 @@ public sealed class RadarControl : Control
         _lastSweepAngle = sweepAngle;
     }
 
-    private bool DidSweepCross(float lastAngle, float currentAngle, float targetAngle)
+    private static bool DidSweepCross(float lastAngle, float currentAngle, float targetAngle)
     {
-        // Normal crossing check
-        if ((lastAngle <= targetAngle && currentAngle >= targetAngle) ||
-            (lastAngle >= targetAngle && currentAngle <= targetAngle))
+        // Normalize all angles to [0, 2*PI) for consistent comparison
+        var normLast = NormalizeAngle(lastAngle);
+        var normCurrent = NormalizeAngle(currentAngle);
+        var normTarget = NormalizeAngle(targetAngle);
+
+        if (normLast <= normCurrent)
         {
-            return true;
+            // No wraparound: target crossed if between last and current
+            return normTarget >= normLast && normTarget <= normCurrent;
         }
 
-        // Handle wraparound from PI to -PI
-        if (lastAngle > MathF.PI / 2 && currentAngle < -MathF.PI / 2)
-        {
-            if (targetAngle > lastAngle || targetAngle < currentAngle)
-                return true;
-        }
+        // Wraparound (current < last): target crossed if after last OR before current
+        return normTarget >= normLast || normTarget <= normCurrent;
+    }
 
-        // Threshold check for blips very close to sweep
-        if (MathF.Abs(currentAngle - targetAngle) < SweepHitThreshold)
-            return true;
-
-        return false;
+    private static float NormalizeAngle(float angle)
+    {
+        var result = angle % (MathF.PI * 2);
+        if (result < 0)
+            result += MathF.PI * 2;
+        return result;
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Server/_Stalker_EN/Devices/Radar/EntitySystems/AnomalyRadarTargetSourceSystem.cs
+++ b/Content.Server/_Stalker_EN/Devices/Radar/EntitySystems/AnomalyRadarTargetSourceSystem.cs
@@ -35,7 +35,7 @@ public sealed class AnomalyRadarTargetSourceSystem : EntitySystem
             TryComp(args.UserGridUid.Value, out userGrid);
 
         _anomalyBuffer.Clear();
-        _entityLookup.GetEntitiesInRange(args.UserMapCoords, entity.Comp.DetectionRange, _anomalyBuffer);
+        _entityLookup.GetEntitiesInRange(args.UserMapCoords, entity.Comp.DetectionRange, _anomalyBuffer, LookupFlags.Uncontained);
 
         foreach (var target in _anomalyBuffer)
         {

--- a/Content.Server/_Stalker_EN/Devices/Radar/EntitySystems/ArtifactRadarTargetSourceSystem.cs
+++ b/Content.Server/_Stalker_EN/Devices/Radar/EntitySystems/ArtifactRadarTargetSourceSystem.cs
@@ -41,15 +41,11 @@ public sealed class ArtifactRadarTargetSourceSystem : EntitySystem
             TryComp(args.UserGridUid.Value, out userGrid);
 
         _artifactBuffer.Clear();
-        _entityLookup.GetEntitiesInRange(args.UserMapCoords, entity.Comp.DetectionRange, _artifactBuffer);
+        _entityLookup.GetEntitiesInRange(args.UserMapCoords, entity.Comp.DetectionRange, _artifactBuffer, LookupFlags.Uncontained);
 
         foreach (var target in _artifactBuffer)
         {
             if (!target.Comp.Detectable)
-                continue;
-
-            // Zone anomalies should only appear as anomaly blips, not artifact blips.
-            if (_anomalyQuery.HasComponent(target))
                 continue;
 
             if (target.Comp.DetectedLevel > entity.Comp.Level)
@@ -57,25 +53,29 @@ public sealed class ArtifactRadarTargetSourceSystem : EntitySystem
 
             var targetXform = xformQuery.GetComponent(target);
             var targetWorldPos = _transform.GetWorldPosition(targetXform, xformQuery);
-
-            var diff = targetWorldPos - args.UserWorldPos;
-            var distance = diff.Length();
+            var distance = (targetWorldPos - args.UserWorldPos).Length();
 
             if (distance > entity.Comp.DetectionRange)
                 continue;
 
-            // Skip spawners that don't have artifacts ready (empty cooldown spawners)
+            // Process spawner activation for ALL targets (including anomalies)
             if (TryComp<ZoneArtifactSpawnerComponent>(target, out var spawner))
             {
                 if (!_artifactSpawner.Ready((target, spawner)))
-                    continue;
+                    continue; // No artifact ready — skip
 
-                // Spawn artifact if player is close enough (like regular detectors do)
                 if (distance <= entity.Comp.ActivationDistance)
                 {
                     _artifactSpawner.TrySpawn((target, spawner));
-                    continue; // Spawner no longer ready - actual artifact will be found next update
+                    continue; // Spawned — actual artifact appears next update
                 }
+                // Ready spawner: falls through to add blip (even if it's an anomaly)
+            }
+            else if (_anomalyQuery.HasComponent(target))
+            {
+                // Non-spawner anomaly — skip from artifact blips
+                // These show via AnomalyRadarTargetSourceSystem instead
+                continue;
             }
 
             var radarAngle = RadarAngleHelper.CalculateRadarAngle(


### PR DESCRIPTION
## What I changed
- Fixed radar detector entity lookup to use `LookupFlags.Uncontained`, preventing it from detecting artifacts/anomalies inside containers
- Fixed anomaly spawners being incorrectly filtered out of artifact radar when they had a ready artifact to show or activate
- Rewrote the sweep crossing logic in RadarControl to correctly handle angle wraparound at the 0/2*PI boundary instead of using a fragile threshold check and -PI to PI range conversion

## Changelog
author: @teecoding
- fix: Radar detector no longer picks up artifacts and anomalies that are inside containers
- fix: Radar sweep no longer misses blips near the top of the display
- fix: Radar should be rotated correctly. 

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
