### PR TITLE
Balanced M16

### DIFF
--- a/Resources/Locale/en-US/_stalker/entities/objects/weapons/guns/rifles/m16.ftl
+++ b/Resources/Locale/en-US/_stalker/entities/objects/weapons/guns/rifles/m16.ftl
@@ -1,3 +1,3 @@
-ent-STWeaponRifleM16 = M16
-    .desc = Colt M16 - an immortal classic from the Vietnam War. It uses 5.56mm ammo.
+ent-STWeaponRifleM16 = M16A2
+    .desc = Colt M16 - an immortal classic from the Vietnam War. Fires in very fast 3-round bursts, and feeds from 5.56mm magazines. Lacks an optics rail for installing scopes.
     .suffix = ST

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
@@ -21,7 +21,7 @@
         volume: -2
     minAngle: 40 # stalker EN change
     maxAngle: 75 # stalker EN change
-    angleIncrease: 1.5 # stalker EN change
+    angleIncrease: 1.25
     selectedMode: Burst
     availableModes:
     - Burst

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
@@ -12,19 +12,20 @@
   - type: Clothing
     sprite: _Stalker_EN/Objects/Weapons/Guns/Rifles/m16/inhand.rsi # stalker EN change
   - type: Gun
-    fireRate: 4.5
+    fireRate: 6
+    burstFireRate: 12
+    burstCooldown: 0.25 # stalker EN change
     soundGunshot:
       path: /Audio/_Stalker/Effects/Guns/m4.ogg
       params:
         volume: -2
-    minAngle: 50
-    maxAngle: 100
-    angleIncrease: 1
+    minAngle: 40 # stalker EN change
+    maxAngle: 75 # stalker EN change
+    angleIncrease: 1.5 # stalker EN change
     selectedMode: Burst
     availableModes:
     - Burst
     - SemiAuto
-    - FullAuto # stalker EN change
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -42,12 +43,12 @@
         whitelist:
           tags:
           - STWeaponModuleRifleSilencerNato
-      gun_module_scope:
-        name: Scope
-        priority: 2
-        whitelist:
-          tags:
-          - STWeaponModuleRifleScopeNato
+      #gun_module_scope:
+        #name: Scope
+        #priority: 2
+        #whitelist:
+          #tags:
+          #- STWeaponModuleRifleScopeNato
       gun_chamber:
         name: Chamber
         startingItem:
@@ -63,6 +64,6 @@
 - type: entity
   parent: STBaseWeaponRifleM16
   id: STWeaponRifleM16
-  name: M16 # stalker EN change
+  name: M16A2 # stalker EN change
   description: Legendary American rifle from Vietnam era. Appears in the Zone through military depots and black market dealers. Despite its age, remains a formidable weapon in skilled hands.
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
@@ -68,6 +68,6 @@
 - type: entity
   parent: STBaseWeaponRifleM16
   id: STWeaponRifleM16
-  name: M16A2 # stalker EN change
+  name: M16 # stalker EN change
   description: Legendary American rifle from Vietnam era. Appears in the Zone through military depots and black market dealers. Despite its age, remains a formidable weapon in skilled hands.
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/M16.yml
@@ -12,16 +12,20 @@
   - type: Clothing
     sprite: _Stalker_EN/Objects/Weapons/Guns/Rifles/m16/inhand.rsi # stalker EN change
   - type: Gun
-    fireRate: 6
-    burstFireRate: 12
+    #fireRate: 4.5 stalker EN change
+    fireRate: 6 # stalker EN change
+    burstFireRate: 12 # stalker EN change
     burstCooldown: 0.25 # stalker EN change
     soundGunshot:
       path: /Audio/_Stalker/Effects/Guns/m4.ogg
       params:
         volume: -2
+    #minAngle: 50 stalker EN change
+    #maxAngle: 100 stalker EN change
+    #angleIncrease: 1 stalker EN change
     minAngle: 40 # stalker EN change
     maxAngle: 75 # stalker EN change
-    angleIncrease: 1.25
+    angleIncrease: 1
     selectedMode: Burst
     availableModes:
     - Burst
@@ -43,12 +47,12 @@
         whitelist:
           tags:
           - STWeaponModuleRifleSilencerNato
-      #gun_module_scope:
-        #name: Scope
-        #priority: 2
-        #whitelist:
-          #tags:
-          #- STWeaponModuleRifleScopeNato
+      #gun_module_scope: stalker EN change
+        #name: Scope stalker EN change
+        #priority: 2 stalker EN change
+        #whitelist: stalker EN change
+          #tags: stalker EN change
+          #- STWeaponModuleRifleScopeNato stalker EN change
       gun_chamber:
         name: Chamber
         startingItem:

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
@@ -97,10 +97,9 @@
         STWeaponSMGMP5: 1800 # T3
         STWeaponSMGThompson: 3800
         # Nato Rifles
-        STWeaponRifleL85: 2100 # T2
+        STWeaponRifleM16: 2500 # T2
+        STWeaponRifleM16M203: 3500 # T2
         STWeaponRifleSCARH: 6000 # T3
-        STWeaponRifleM16: 4000 # T2
-        STWeaponRifleM16M203: 5000 # T2
         STWeaponRifleFAL: 1750 # T3
         STWeaponRifleFALo: 8000 # T3
         STWeaponRifleGalil: 7000 # T3


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Changed the M16 to a L85 sidegrade, and removed the L85 from Freedom

The M16 now costs 2500r
fires in quick bursts with a long cooldown (12 firerate, 0.25 cooldown)
Has the same accuracy stats as the L85
Cannot mount optics and is burst/semi only (its a M16A2)
<img width="588" height="526" alt="image" src="https://github.com/user-attachments/assets/ef850fe7-a273-412f-b857-6c1f234de704" />

https://github.com/user-attachments/assets/115e66c8-90d4-42cb-b2ea-3274d990d6ff

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Nox38

- add: Redid the M16 into a L85 sidegrade burst gun.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
