### PR TITLE
fix: prevent crash recovery item duplication and stale data issues

### DIFF
--- a/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml.cs
+++ b/Content.Client/_Stalker/StalkerRepository/StalkerRepositoryMenu.xaml.cs
@@ -57,8 +57,12 @@ public sealed partial class StalkerRepositoryMenu : DefaultWindow
         // Loadout button opens separate window
         OpenLoadoutsButton.OnPressed += _ => OpenLoadoutsPressed?.Invoke();
 
-        // stalker-en-changes: Crash recovery button
-        CrashRecoveryButton.OnPressed += _ => CrashRecoveryPressed?.Invoke();
+        // stalker-en-changes: Crash recovery button (hide banner immediately to prevent double-clicks)
+        CrashRecoveryButton.OnPressed += _ =>
+        {
+            CrashRecoveryBanner.Visible = false;
+            CrashRecoveryPressed?.Invoke();
+        };
     }
 
     // stalker-en-changes

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -1872,6 +1872,16 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
                 .ExecuteUpdateAsync(s => s.SetProperty(r => r.CrashRecovery, (string?) null));
         }
 
+        public async Task<List<string>> GetAllCrashRecoveryLogins()
+        {
+            await using var db = await GetDb();
+
+            return await db.DbContext.Stalkers
+                .Where(s => s.CrashRecovery != null && s.Login != null)
+                .Select(s => s.Login!)
+                .ToListAsync();
+        }
+
         public async Task SetCrashRecoveryBatch(Dictionary<string, string> loginToJson)
         {
             await using var db = await GetDb();

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -382,6 +382,7 @@ namespace Content.Server.Database
         Task SetCrashRecovery(string login, string? jsonItems);
         Task<string?> GetCrashRecovery(string login);
         Task ClearAllCrashRecovery();
+        Task<List<string>> GetAllCrashRecoveryLogins();
         Task SetCrashRecoveryBatch(Dictionary<string, string> loginToJson);
         Task SetStalkerStatsAsync(string login, CharacteristicType characteristic, float value, DateTime? trainTime);
         Task<StalkerStats?> GetStalkerStatAsync(string login, CharacteristicType characteristic);
@@ -1533,6 +1534,12 @@ namespace Content.Server.Database
         {
             DbWriteOpsMetric.Inc();
             return RunDbCommand(() => _db.ClearAllCrashRecovery());
+        }
+
+        public Task<List<string>> GetAllCrashRecoveryLogins()
+        {
+            DbReadOpsMetric.Inc();
+            return RunDbCommand(() => _db.GetAllCrashRecoveryLogins());
         }
 
         public Task SetCrashRecoveryBatch(Dictionary<string, string> loginToJson)

--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -221,8 +221,10 @@ public sealed class StalkerRepositorySystem : EntitySystem
         // Note: Loadout state is sent on demand when user opens the loadout menu,
         // not here, to avoid race conditions with the async database call.
 
-        // stalker-en-changes: Check for crash recovery data (async — arrives on next tick)
-        _crashRecovery.CheckAndSendCrashRecoveryState(uid, args.User);
+        // stalker-en-changes: Check for crash recovery data only on personal stash
+        // StorageOwner uses prefixes (e.g. "PB" for personal box), so use EndsWith
+        if (TryComp<ActorComponent>(args.User, out var actor) && component.StorageOwner.EndsWith(actor.PlayerSession.Name))
+            _crashRecovery.CheckAndSendCrashRecoveryState(uid, args.User);
     }
 
     private void UpdateUiState(EntityUid? user, EntityUid repository, StalkerRepositoryComponent? component = null)
@@ -299,6 +301,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
                 EjectItems(GetEntity(msg.Entity), item, msg.Count);
                 _adminLogger.Add(LogType.Action, LogImpact.Low, $"Player {Name(msg.Actor):user} ejected {msg.Count} {msg.Item.Name} from repository");
                 _stalkerStorageSystem.SaveStorage(component);
+                _crashRecovery.ImmediateSnapshot(msg.Actor);
                 UpdateUiState(msg.Actor, GetEntity(msg.Entity), component);
                 _loadoutSystem.SendLoadoutStateUpdate(GetEntity(msg.Entity), component, msg.Actor);
             }
@@ -347,6 +350,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
         // logging, saving, ui updating
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"Player {Name(msg.Actor):user} inserted {msg.Count} {msg.Item.Name} into repository");
         _stalkerStorageSystem.SaveStorage(component);
+        _crashRecovery.ImmediateSnapshot(msg.Actor);
         RaiseLocalEvent(msg.Actor, new RepositoryItemInjectedEvent(uid, msg.Item));
         UpdateUiState(msg.Actor, GetEntity(msg.Entity), component);
         _loadoutSystem.SendLoadoutStateUpdate(uid, component, msg.Actor);
@@ -389,6 +393,7 @@ public sealed class StalkerRepositorySystem : EntitySystem
         // logging, saving, ui updating
         _adminLogger.Add(LogType.Action, LogImpact.Low, $"Player {Name(args.User):user} inserted 1 {itemInfo.Name} into repository");
         _stalkerStorageSystem.SaveStorage(component);
+        _crashRecovery.ImmediateSnapshot(args.User);
         RaiseLocalEvent(args.User, new RepositoryItemInjectedEvent(args.Target, itemInfo));
         // stalker-changes: only update UI if already open, don't open it just from inserting an item
         if (_ui.IsUiOpen(uid, StalkerRepositoryUiKey.Key, args.User))

--- a/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
+++ b/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
@@ -59,6 +59,9 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
     // Concurrent operation protection for claims
     private readonly ConcurrentDictionary<EntityUid, byte> _currentlyProcessingClaims = new();
 
+    // Logins with unclaimed recovery data — snapshots must not overwrite these
+    private readonly HashSet<string> _pendingRecoveryLogins = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -80,6 +83,11 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
     {
         base.Shutdown();
 
+        // Clear crash recovery on graceful shutdown.
+        // On real crashes, the process dies without reaching here, so data persists correctly.
+        if (_enabled)
+            _dbManager.ClearAllCrashRecovery();
+
         _cfg.UnsubValueChanged(STCCVars.CrashRecoveryEnabled, v => _enabled = v);
         _cfg.UnsubValueChanged(STCCVars.CrashRecoverySaveInterval, v => _saveInterval = v);
     }
@@ -93,7 +101,28 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         _timeSinceLastSave = 0;
         _snapshotQueue.Clear();
         _dirtyPlayers.Clear();
+        _pendingRecoveryLogins.Clear();
         _sawmill.Info("Crash recovery game rule started");
+
+        // Load logins with unclaimed recovery data so periodic snapshots don't overwrite them
+        LoadPendingRecoveryLogins();
+    }
+
+    private async void LoadPendingRecoveryLogins()
+    {
+        try
+        {
+            var logins = await _dbManager.GetAllCrashRecoveryLogins();
+            foreach (var login in logins)
+                _pendingRecoveryLogins.Add(login);
+
+            if (logins.Count > 0)
+                _sawmill.Info($"Loaded {logins.Count} pending crash recovery logins");
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Failed to load pending crash recovery logins: {e}");
+        }
     }
 
     protected override void Ended(EntityUid uid, CrashRecoveryRuleComponent component,
@@ -108,6 +137,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         _dbManager.ClearAllCrashRecovery();
         _snapshotQueue.Clear();
         _dirtyPlayers.Clear();
+        _pendingRecoveryLogins.Clear();
         _timeSinceLastSave = 0;
     }
 
@@ -157,6 +187,14 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         if (!TryComp<ActorComponent>(actor, out var actorComp))
             return;
 
+        // Don't show banner if a claim is already being processed
+        if (_currentlyProcessingClaims.ContainsKey(actor))
+        {
+            _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
+                new CrashRecoveryUpdateState(false, 0));
+            return;
+        }
+
         var login = actorComp.PlayerSession.Name;
 
         try
@@ -168,10 +206,14 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
             if (string.IsNullOrEmpty(json))
             {
+                _pendingRecoveryLogins.Remove(login);
                 _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
                     new CrashRecoveryUpdateState(false, 0));
                 return;
             }
+
+            // Mark this login as having unclaimed recovery data so snapshots don't overwrite it
+            _pendingRecoveryLogins.Add(login);
 
             var itemCount = 0;
             try
@@ -223,6 +265,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
             // Clear FIRST (optimistic — prevents duplication if spawn crashes)
             await _dbManager.SetCrashRecovery(login, null);
+            _pendingRecoveryLogins.Remove(login);
 
             if (!Exists(uid) || !Exists(msg.Actor))
                 return;
@@ -307,6 +350,10 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
             var login = session.Name;
 
+            // Don't overwrite unclaimed recovery data from a previous crash
+            if (_pendingRecoveryLogins.Contains(login))
+                continue;
+
             try
             {
                 var data = CapturePlayerState(playerEntity);
@@ -373,6 +420,10 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
                 continue;
 
             var login = session.Name;
+
+            // Don't overwrite unclaimed recovery data from a previous crash
+            if (_pendingRecoveryLogins.Contains(login))
+                continue;
 
             try
             {
@@ -459,6 +510,43 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
                 CaptureItemRecursive(contained, inventory, depth + 1);
             }
+        }
+    }
+
+    /// <summary>
+    /// Immediately snapshots a player's equipped state to DB.
+    /// Called when stash contents change to keep crash recovery in sync.
+    /// </summary>
+    public void ImmediateSnapshot(EntityUid player)
+    {
+        if (!_enabled)
+            return;
+
+        if (!TryComp<ActorComponent>(player, out var actorComp))
+            return;
+
+        if (!HasComp<InventoryComponent>(player))
+            return;
+
+        var login = actorComp.PlayerSession.Name;
+
+        // Don't overwrite unclaimed recovery data from a previous crash
+        if (_pendingRecoveryLogins.Contains(login))
+            return;
+
+        try
+        {
+            var data = CapturePlayerState(player);
+            if (data != null)
+                _dbManager.SetCrashRecoveryBatch(new Dictionary<string, string> { { login, data } });
+            else
+                _dbManager.SetCrashRecovery(login, null);
+
+            _dirtyPlayers.Remove(player);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"Failed immediate snapshot for {login}: {e}");
         }
     }
 


### PR DESCRIPTION
## What I changed

Fixed multiple bugs in the crash recovery system:

1. Items stored in stash before a crash were being duplicated on recovery (existed in both stash and spawned at feet). Now takes an immediate snapshot when stash contents change so recovery data stays in sync.
2. Recovery button could be clicked multiple times, duplicating items each click. Now hides the button immediately on click and blocks re-showing during processing.
3. Normal server shutdown (no crash) still showed the recovery button on next restart. Now clears recovery data on graceful shutdown.
4. Recovery button appeared on shared/band stashes where it shouldn't. Now only shows on personal stash.
5. Periodic snapshots could overwrite unclaimed recovery data from a previous crash, causing players to lose their items. Now tracks pending recovery logins and skips them during snapshots.

## Changelog

author: @teecoding

- fix: Crash recovery no longer duplicates items that were already in your stash
- fix: Crash recovery button can no longer be clicked multiple times to duplicate items
- fix: Crash recovery button no longer appears after a normal server restart
- fix: Crash recovery button no longer appears on shared stashes

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
