### PR TITLE
fix: prevent crash recovery banner from showing during normal play

### DIFF
--- a/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
+++ b/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
@@ -197,6 +197,15 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
         var login = actorComp.PlayerSession.Name;
 
+        // Only show recovery for data that existed at round start (from a crash).
+        // Data written during the current session by periodic/immediate snapshots is not recoverable.
+        if (!_pendingRecoveryLogins.Contains(login))
+        {
+            _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
+                new CrashRecoveryUpdateState(false, 0));
+            return;
+        }
+
         try
         {
             var json = await _dbManager.GetCrashRecovery(login);
@@ -211,9 +220,6 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
                     new CrashRecoveryUpdateState(false, 0));
                 return;
             }
-
-            // Mark this login as having unclaimed recovery data so snapshots don't overwrite it
-            _pendingRecoveryLogins.Add(login);
 
             var itemCount = 0;
             try


### PR DESCRIPTION
## What I changed

Fixed crash recovery banner appearing during normal gameplay, letting players duplicate equipped items. The system wasn't distinguishing between snapshot data from the current session vs stale data from an actual crash.

## Changelog

author: @teecoding

- fix: Fixed crash recovery offering to restore items during normal play, causing item duplication

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
