### PR TITLE
fix: stop crash recovery state from overwriting stash UI and ensure graceful shutdown clears DB

### DIFF
--- a/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
+++ b/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
@@ -86,7 +86,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         // Clear crash recovery on graceful shutdown.
         // On real crashes, the process dies without reaching here, so data persists correctly.
         if (_enabled)
-            _dbManager.ClearAllCrashRecovery();
+            _dbManager.ClearAllCrashRecovery().GetAwaiter().GetResult();
 
         _cfg.UnsubValueChanged(STCCVars.CrashRecoveryEnabled, v => _enabled = v);
         _cfg.UnsubValueChanged(STCCVars.CrashRecoverySaveInterval, v => _saveInterval = v);
@@ -189,22 +189,14 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
         // Don't show banner if a claim is already being processed
         if (_currentlyProcessingClaims.ContainsKey(actor))
-        {
-            _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
-                new CrashRecoveryUpdateState(false, 0));
             return;
-        }
 
         var login = actorComp.PlayerSession.Name;
 
         // Only show recovery for data that existed at round start (from a crash).
         // Data written during the current session by periodic/immediate snapshots is not recoverable.
         if (!_pendingRecoveryLogins.Contains(login))
-        {
-            _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
-                new CrashRecoveryUpdateState(false, 0));
             return;
-        }
 
         try
         {
@@ -216,8 +208,6 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
             if (string.IsNullOrEmpty(json))
             {
                 _pendingRecoveryLogins.Remove(login);
-                _ui.SetUiState(repository, StalkerRepositoryUiKey.Key,
-                    new CrashRecoveryUpdateState(false, 0));
                 return;
             }
 
@@ -318,9 +308,6 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
             _popup.PopupEntity(Loc.GetString("crash-recovery-claimed"), msg.Actor, msg.Actor,
                 PopupType.Medium);
-
-            _ui.SetUiState(uid, StalkerRepositoryUiKey.Key,
-                new CrashRecoveryUpdateState(false, 0));
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## What I changed
`CrashRecoveryUpdateState` was overwriting `RepositoryUpdateState` on same BUI key, causing empty stash for all players. Removed unnecessary state sends. Also made graceful shutdown block on DB clear so crash recovery data doesn't persist after normal restart.

## Changelog
author: @teecoding

- fix: Stash no longer appears empty when opening personal storage
- fix: Crash recovery banner no longer shows after normal server restart

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
