### PR TITLE
fix: clear crash recovery data on graceful server shutdown

### DIFF
--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -37,6 +37,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Server._Stalker.Sponsors.SponsorManager; // Stalker-Using
+using Content.Shared._Stalker_EN.CCVar;
 
 namespace Content.Server.Entry
 {
@@ -215,6 +216,19 @@ namespace Content.Server.Entry
 
         protected override void Dispose(bool disposing)
         {
+            // Clear crash recovery data on graceful shutdown.
+            // On real crashes the process dies without reaching Dispose(),
+            // so snapshot data persists correctly for the next round.
+            try
+            {
+                if (_cfg.GetCVar(STCCVars.CrashRecoveryEnabled))
+                    _dbManager.ClearAllCrashRecovery().GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                _log.GetSawmill("crash-recovery").Error($"Failed to clear crash recovery on shutdown: {e}");
+            }
+
             var dest = _cfg.GetCVar(CCVars.DestinationFile);
             if (!string.IsNullOrEmpty(dest))
             {


### PR DESCRIPTION
## What I changed

  Fixed crash recovery button appearing after normal server restarts (e.g. delayed_restart). The crash recovery data 
  was not being cleared on graceful shutdown because EntitySystem.Shutdown() is never called server-side during 
  BaseServer.Cleanup(). Moved the clear call to EntryPoint.Dispose(), which runs on all graceful shutdown paths.     
           
  ## Changelog                           

  author: @teecoding

  - fix: Crash recovery button no longer appears after normal server restarts

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes     
  - [X] I agree that by submitting a PR I agree to the terms of the 
  [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).                               
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are 
  under an open license