### PR TITLE
Revert "Remove double waist bags from shops"

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
@@ -319,6 +319,7 @@
       ClothingBeltBandolierStalker: 20 # T1 - PVE
       STClothingBeltThrowingKnifes: 350
       ClothingBeltWebbingHolsterStalkerZarya: 500
+      ClothingBeltWebbingDoubleStalkerZaryaSmall: 1000
       # Containers
       MedkitCMSStalker: 450 # T1
       MedkitGrizzlyStalker: 850 # T2

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
@@ -210,7 +210,8 @@
         ClothingOuterJacketFreedom: 60 # T1 - PVE
         STClothingOuterArmorLightPlateVestBaseFreedom: 1000 # T2 - PvP
         ClothingOuterArmorRCBZFreedom: 1700 # T2 - ENV
-        ClothingOuterArmorFreedomWind: 2000 # T2
+        ClothingOuterArmorFreedomWind: 2000
+        SetFreedomVeterBuyableCrate: 3200 # T2 Bundle
         SetFreedomDefenderBuyableCrate: 12000 # T3
         ClothingOuterArmorAborigineFreedom: 8500 # T3
         ClothingOuterArmorSevaFreedom: 3200 # T3 - ENV
@@ -228,6 +229,7 @@
           # Belts
         ClothingBeltBandolierStalker: 20 # T1 - PVE
         ClothingBeltWebbingHolsterFreedomDefender: 600
+        ClothingBeltWebbingDoubleFreedomVeterSmall: 1000
 
     - name: shop-category-raincoats-and-gasmasks
       priority: 8

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/renegades.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/renegades.yml
@@ -108,7 +108,7 @@
       SledgehammerRenegats: 500
       StalkerBallBat: 120
         # Guns
-      #20gauge
+      #20gauge  
       STBaseWeaponShotgunTOZ106: 500 # T1
       # 7mm
       STWeaponShotgunMP155T: 45 #T0.5
@@ -252,6 +252,7 @@
       ClothingBeltBandolierStalker: 20 # T1 - PVE
       ClothingBeltTarzanOrange: 200 # T1 - PVP
       ClothingBeltWebbingHolsterStalkerZarya: 500
+      ClothingBeltWebbingDoubleStalkerZaryaSmall: 1000
       # Containers
       MedkitCMSStalker: 400 # T1
       MedkitGrizzlyStalker: 1000 # T2

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
@@ -368,6 +368,7 @@
         ClothingBeltPocketPouch: 450
         ClothingBeltHerbalistPouch: 450
         ClothingBeltWebbingHolsterStalkerZarya: 1000
+        ClothingBeltWebbingDoubleStalkerZaryaSmall: 1500
         ClothingBeltCrafterStalker: 3000
 
     - name: shop-category-raincoats-and-gasmasks

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sidorovich.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Sidorovich.yml
@@ -212,7 +212,7 @@
       items:
         #20gauge
         62mmBuckshotBox: 30 #T0
-        75mmBuckshotBox: 200 #T1
+        75mmBuckshotBox: 200 #T1     
         #7mm
         7mmBuckshotBox: 50 # T0
         6mmBuckshotBox: 275 # T1
@@ -317,6 +317,7 @@
         ClothingBeltTarzanGreen: 200 # T1 - PVP
         ClothingBeltTarzanOrange: 200 # T1 - PVP
         ClothingBeltWebbingHolsterStalkerZarya: 1000
+        ClothingBeltWebbingDoubleStalkerZaryaSmall: 1500
           # Containers
         MedkitCMSStalker: 250 # T1
         MedkitGrizzlyStalker: 850 # T2

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/Tooth.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/PawnShops/PawnShops/Tooth.yml
@@ -270,6 +270,7 @@
       ClothingBeltPocketPouch: 350
       ClothingBeltHerbalistPouch: 350
       ClothingBeltWebbingHolsterStalkerZarya: 1350
+      ClothingBeltWebbingDoubleStalkerZaryaSmall: 2000
       ClothingBeltCrafterStalker: 4000
 
   - name: shop-category-raincoats-and-gasmasks


### PR DESCRIPTION
Reverts stalker-14-EN/stalker-14-EN#824

The talk in the original pr was about "The double waist bags were objectively better than single ones with no downsides" and just generally the old waist bag being less useful overall the the new one being power creep.

There are many things that can be done BESIDES removing the bag everyone likes and is already highly in circulation.
- increase the price of it
- Increase the weight of it
- Give the other waist bag less weight or more smaller pockets

The list goes on. Generally regarding game design removing something entirely to make a weaker option more appealing doesn't make anyone happy. There are a LOT of items that are pure upgrades compared to the rest. Instead of nerfing the things people use generally you should buff the underperformers, barring extreme outliers of course. The bag doesn't seem like an extreme outlier or any sort of problem.

If the double waist bag was argued to be providing TOO MUCH space for stalkers, that would be understandable, but that was not brought up in the original PR - the reason was that no one was using the old one anymore. In any case the old PR doesn't really have enough justification for removing something so minor imo and is just overall an unfun change for no benefit. This isn't solving any giant powercreep problem or anything.