### PR TITLE
tooth necklace fix

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Clothing/Neck/Toothnecklace.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Clothing/Neck/Toothnecklace.yml
@@ -8,13 +8,22 @@
     sprite: _Stalker_EN/Objects/Clothing/Neck/Toothnecklace.rsi
   - type: Clothing
     sprite: _Stalker_EN/Objects/Clothing/Neck/Toothnecklace.rsi
-  - type: BallisticAmmoProvider
-    mayTransfer: true
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,8,1
+    quickInsert: true
+    areaInsert: true
     whitelist:
       tags:
       - Stalkertooth
-    capacity: 9
-  - type: MagazineVisuals
-    magState: mag
-    steps: 5
-    zeroVisible: false
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: [ ]
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: RepositoryItem
+    categoryName: repository-clothing-category


### PR DESCRIPTION
## What I changed
- had to change it to grid storage, something about the way it was done was making the repository mad

## Changelog
author: @crocodilecarousel 

- fix: Tooth Necklace can now be stashed, and will be under the Clothing category

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
