### PR TITLE
Less laggy lightning

### DIFF
--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -1,12 +1,12 @@
-using System.Linq; // Stalker-EN
 using Content.Server.Lightning;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
 using Content.Shared._Stalker.ZoneAnomaly.Components;
 using Content.Shared._Stalker.ZoneAnomaly.Effects.Components;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Whitelist;
-using NetCord;
-using Robust.Shared.Random;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server._Stalker.ZoneAnomaly.Effects.Systems;
 
@@ -18,41 +18,37 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly LightningSystem _lightning = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    [Dependency] private readonly IRobustRandom _random = default!; // Stalker-EN changes
 
     public override void Initialize()
     {
         SubscribeLocalEvent<ZoneAnomalyEffectLightArcComponent, ZoneAnomalyActivateEvent>(OnActivate);
     }
 
-    // Stalker-EN changes - We rewrote everything below here, dont take upstream changes
     private void OnActivate(Entity<ZoneAnomalyEffectLightArcComponent> effect, ref ZoneAnomalyActivateEvent args)
     {
-        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates,
-            effect.Comp.Distance,
-            flags: LookupFlags.Uncontained);
-
         var i = 0;
+        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates, effect.Comp.Distance, LookupFlags.Uncontained);
         foreach (var entity in entities)
         {
-            if (i >= MaxIterations)
+            if (i > MaxIterations)
                 break;
 
-            if (!_whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, entity))
+            // We don't need to shoot all the entities
+            if(!_whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, entity))
                 continue;
 
             TryRecharge(effect, entity);
             _lightning.ShootLightning(effect, entity, effect.Comp.Lighting);
+
             i++;
         }
     }
 
     private void TryRecharge(Entity<ZoneAnomalyEffectLightArcComponent> effect, Entity<PredictedBatteryComponent?> target)
     {
-        if(!Resolve(target, ref target.Comp, false))
+        if (!Resolve(target, ref target.Comp))
             return;
 
-        _battery.SetCharge(target, target.Comp.LastCharge + target.Comp.MaxCharge * effect.Comp.ChargePercent);
+        _battery.SetCharge((target, target.Comp), target.Comp.LastCharge + target.Comp.MaxCharge * effect.Comp.ChargePercent);
     }
-    // stalker-en-end
 }

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -31,11 +31,12 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
             .Where(x => _whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, x))
             .ToList();
 
+        _random.Shuffle(entities);
+
         for (var i = 0; i < MaxIterations; i++)
         {
-            var target = _random.PickAndTake(entities);
-            TryRecharge(effect, target);
-            _lightning.ShootLightning(effect, target, effect.Comp.Lighting);
+            TryRecharge(effect, entities[i]);
+            _lightning.ShootLightning(effect, entities[i], effect.Comp.Lighting);
         }
     }
 

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -49,7 +49,7 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
     private void TryRecharge(Entity<ZoneAnomalyEffectLightArcComponent> effect, Entity<PredictedBatteryComponent?> target)
     {
         // stalker-en - changed from trycomp to resolve for minor performance
-        if (!Resolve(target, ref target.Comp))
+        if (!Resolve(target, ref target.Comp, false))
             return;
 
         _battery.SetCharge((target, target.Comp), target.Comp.LastCharge + target.Comp.MaxCharge * effect.Comp.ChargePercent);

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -1,12 +1,11 @@
+using System.Linq; // Stalker-EN
 using Content.Server.Lightning;
-using Content.Server.Power.Components;
-using Content.Server.Power.EntitySystems;
 using Content.Shared._Stalker.ZoneAnomaly.Components;
 using Content.Shared._Stalker.ZoneAnomaly.Effects.Components;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Whitelist;
-using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server._Stalker.ZoneAnomaly.Effects.Systems;
 
@@ -18,50 +17,34 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly LightningSystem _lightning = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!; // Stalker-EN changes
 
     public override void Initialize()
     {
         SubscribeLocalEvent<ZoneAnomalyEffectLightArcComponent, ZoneAnomalyActivateEvent>(OnActivate);
     }
 
+    // Stalker-EN changes - We rewrote everything below here, dont take upstream changes
     private void OnActivate(Entity<ZoneAnomalyEffectLightArcComponent> effect, ref ZoneAnomalyActivateEvent args)
     {
-        var i = 0;
-        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates, effect.Comp.Distance);
-        foreach (var entity in entities)
+        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates, effect.Comp.Distance, flags: LookupFlags.Uncontained)
+            .Where(x => _whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, x))
+            .ToList();
+
+        for (var i = 0; i < MaxIterations; i++)
         {
-            if (i > MaxIterations)
-                break;
-
-            // We don't need to shoot all the entities
-            if(!_whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, entity))
-                continue;
-
-            // Fixes 10 million shots being fired at one entity due to it containing targets
-            if (IsValidRecursively(effect, entity))
-                continue;
-
-            TryRecharge(effect, entity);
-            _lightning.ShootLightning(effect, entity, effect.Comp.Lighting);
-
-            i++;
+            var target = _random.PickAndTake(entities);
+            TryRecharge(effect, target);
+            _lightning.ShootLightning(effect, target, effect.Comp.Lighting);
         }
     }
 
-    private void TryRecharge(Entity<ZoneAnomalyEffectLightArcComponent> effect, EntityUid target)
+    private void TryRecharge(Entity<ZoneAnomalyEffectLightArcComponent> effect, Entity<PredictedBatteryComponent?> target)
     {
-        if (!TryComp<PredictedBatteryComponent>(target, out var battery))
+        if(!Resolve(target, ref target.Comp, false))
             return;
 
-        _battery.SetCharge((target, battery), battery.LastCharge + battery.MaxCharge * effect.Comp.ChargePercent);
+        _battery.SetCharge(target, target.Comp.LastCharge + target.Comp.MaxCharge * effect.Comp.ChargePercent);
     }
-
-    private bool IsValidRecursively(Entity<ZoneAnomalyEffectLightArcComponent> effect, EntityUid uid)
-    {
-        var parent = Transform(uid).ParentUid;
-        if (HasComp<MapComponent>(parent) || HasComp<MapGridComponent>(parent))
-            return false;
-
-        return _whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, parent) || IsValidRecursively(effect, parent);
-    }
+    // stalker-en-end
 }

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -24,9 +24,11 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
         SubscribeLocalEvent<ZoneAnomalyEffectLightArcComponent, ZoneAnomalyActivateEvent>(OnActivate);
     }
 
+    // stalker-en We no longer have to validate recursively, because we are just filtering
     private void OnActivate(Entity<ZoneAnomalyEffectLightArcComponent> effect, ref ZoneAnomalyActivateEvent args)
     {
         var i = 0;
+        // Stalker-en - filter for uncontained items
         var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates, effect.Comp.Distance, LookupFlags.Uncontained);
         foreach (var entity in entities)
         {
@@ -46,6 +48,7 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
 
     private void TryRecharge(Entity<ZoneAnomalyEffectLightArcComponent> effect, Entity<PredictedBatteryComponent?> target)
     {
+        // stalker-en - changed from trycomp to resolve for minor performance
         if (!Resolve(target, ref target.Comp))
             return;
 

--- a/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
+++ b/Content.Server/_Stalker/ZoneAnomaly/Effects/Systems/ZoneAnomalyEffectLightArcSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._Stalker.ZoneAnomaly.Effects.Components;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Whitelist;
+using NetCord;
 using Robust.Shared.Random;
 
 namespace Content.Server._Stalker.ZoneAnomaly.Effects.Systems;
@@ -27,16 +28,22 @@ public sealed class ZoneAnomalyEffectLightArcSystem : EntitySystem
     // Stalker-EN changes - We rewrote everything below here, dont take upstream changes
     private void OnActivate(Entity<ZoneAnomalyEffectLightArcComponent> effect, ref ZoneAnomalyActivateEvent args)
     {
-        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates, effect.Comp.Distance, flags: LookupFlags.Uncontained)
-            .Where(x => _whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, x))
-            .ToList();
+        var entities = _lookup.GetEntitiesInRange(Transform(effect).Coordinates,
+            effect.Comp.Distance,
+            flags: LookupFlags.Uncontained);
 
-        _random.Shuffle(entities);
-
-        for (var i = 0; i < MaxIterations; i++)
+        var i = 0;
+        foreach (var entity in entities)
         {
-            TryRecharge(effect, entities[i]);
-            _lightning.ShootLightning(effect, entities[i], effect.Comp.Lighting);
+            if (i >= MaxIterations)
+                break;
+
+            if (!_whitelistSystem.IsWhitelistPass(effect.Comp.Whitelist, entity))
+                continue;
+
+            TryRecharge(effect, entity);
+            _lightning.ShootLightning(effect, entity, effect.Comp.Lighting);
+            i++;
         }
     }
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/electrical.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Anomalies/electrical.yml
@@ -146,7 +146,7 @@
   components:
     - type: Tag
       tags:
-        - AnomalyGarlandActivationTarget
+        #- AnomalyGarlandActivationTarget # stalker-en - disable self-activation for performance
         - HideContextMenu
     - type: ZoneAnomalyTriggerStartCollide
     - type: ZoneAnomalyTriggerEndCollide


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->

This should make it so electric anoms don't lag the entire server, with a few drawbacks:
- Electric anoms will no longer activate each other
- They will no longer hit items within containers

Also another minor optimization, which is backend only

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @DuckManZach 

- tweak: Electric anoms will no longer activate eachother, but are less laggy

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
