### PR TITLE
Standardised the results from crafting between T0-T3 ammo

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
@@ -4,6 +4,8 @@
   id: newrecipe7mmBuckshotBoxCink
   resultProtos:
     - 7mmBuckshotBoxCink
+    - 7mmBuckshotBoxCink
+    - 7mmBuckshotBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -19,6 +21,8 @@
   id: newrecipe6mmBuckshotBoxCink
   resultProtos:
     - 6mmBuckshotBoxCink
+    - 6mmBuckshotBoxCink
+    - 6mmBuckshotBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -33,6 +37,7 @@
 - type: craftRecipe
   id: newrecipe8mmBuckshotBoxCink
   resultProtos:
+    - 8mmBuckshotBoxCink
     - 8mmBuckshotBoxCink
     - 8mmBuckshotBoxCink
   craftTime: 30
@@ -102,6 +107,7 @@
   resultProtos:
     - ShotgunBulletBoxRIPCink
     - ShotgunBulletBoxRIPCink
+    - ShotgunBulletBoxRIPCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -137,6 +143,7 @@
   resultProtos:
     - 545FMJBoxCink
     - 545FMJBoxCink
+    - 545FMJBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -168,6 +175,7 @@
 - type: craftRecipe
   id: newrecipe545HPBoxCink
   resultProtos:
+    - 545HPBoxCink
     - 545HPBoxCink
     - 545HPBoxCink
   craftTime: 30
@@ -242,6 +250,8 @@
   id: newrecipe918PGJBoxCink
   resultProtos:
     - 918PGJBoxCink
+    - 918PGJBoxCink
+    - 918PGJBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -258,6 +268,7 @@
   resultProtos:
     - 918PSTBoxCink
     - 918PSTBoxCink
+    - 918PSTBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -272,6 +283,7 @@
 - type: craftRecipe
   id: newrecipe918SP7BoxCink
   resultProtos:
+    - 918SP7BoxCink
     - 918SP7BoxCink
     - 918SP7BoxCink
   craftTime: 30
@@ -308,6 +320,8 @@
   id: newrecipe919PSOGJBoxCink
   resultProtos:
     - 919PSOGJBoxCink
+    - 919PSOGJBoxCink
+    - 919PSOGJBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -324,6 +338,7 @@
   resultProtos:
     - 919PSTBoxCink
     - 919PSTBoxCink
+    - 919PSTBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -338,6 +353,7 @@
 - type: craftRecipe
   id: newrecipe919RIPBoxCink
   resultProtos:
+    - 919RIPBoxCink
     - 919RIPBoxCink
     - 919RIPBoxCink
   craftTime: 30
@@ -375,6 +391,7 @@
   resultProtos:
     - 556FMJBoxCink
     - 556FMJBoxCink
+    - 556FMJBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -406,6 +423,7 @@
 - type: craftRecipe
   id: newrecipe556WarmagBoxCink
   resultProtos:
+    - 556WarmagBoxCink
     - 556WarmagBoxCink
     - 556WarmagBoxCink
   craftTime: 35
@@ -479,6 +497,8 @@
   id: newrecipe725PBoxCink
   resultProtos:
     - 725PBoxCink
+    - 725PBoxCink
+    - 725PBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -493,6 +513,7 @@
 - type: craftRecipe
   id: newrecipe725PTBoxCink
   resultProtos:
+    - 725PTBoxCink
     - 725PTBoxCink
     - 725PTBoxCink
   craftTime: 30
@@ -692,6 +713,8 @@
   id: newrecipe45ACPLFMJBoxCink
   resultProtos:
     - 45ACPLFMJBoxCink
+    - 45ACPLFMJBoxCink
+    - 45ACPLFMJBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -706,6 +729,7 @@
 - type: craftRecipe
   id: newrecipe45ACPMFMJBoxCink
   resultProtos:
+    - 45ACPMFMJBoxCink
     - 45ACPMFMJBoxCink
     - 45ACPMFMJBoxCink
   craftTime: 30
@@ -724,6 +748,7 @@
   resultProtos:
     - 45ACPHydroshockBoxCink
     - 45ACPHydroshockBoxCink
+    - 45ACPHydroshockBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -738,6 +763,7 @@
 - type: craftRecipe
   id: newrecipe45ACPRIPBoxCink
   resultProtos:
+    - 45ACPRIPBoxCink
     - 45ACPRIPBoxCink
     - 45ACPRIPBoxCink
   craftTime: 30
@@ -775,6 +801,7 @@
   resultProtos:
     - 939SP5BoxCink
     - 939SP5BoxCink
+    - 939SP5BoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -810,6 +837,8 @@
   id: newrecipe1255PS12ACink
   resultProtos:
     - Ammobox1255PS12ACink
+    - Ammobox1255PS12ACink
+    - Ammobox1255PS12ACink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -824,6 +853,7 @@
 - type: craftRecipe
   id: newrecipe1255TPCink
   resultProtos:
+    - Ammobox1255TPCink
     - Ammobox1255TPCink
     - Ammobox1255TPCink
   craftTime: 30
@@ -895,6 +925,7 @@
 - type: craftRecipe
   id: newrecipe754HPBoxCink
   resultProtos:
+    - 754HPBoxCink
     - 754HPBoxCink
     - 754HPBoxCink
   craftTime: 30

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
@@ -921,7 +921,6 @@
   resultProtos:
     - 754HPBoxCink
     - 754HPBoxCink
-    - 754HPBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Craft/Recipes/Ammo.yml
@@ -170,7 +170,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 5
+      amount: 4
 
 - type: craftRecipe
   id: newrecipe545HPBoxCink
@@ -187,7 +187,7 @@
     CraftMaterialGunpowder:
       amount: 4
     STCraftSheetBrassT3:
-      amount: 3
+      amount: 2
 
 - type: craftRecipe
   id: newrecipe545BPBoxCink
@@ -295,7 +295,7 @@
     CraftMaterialGunpowder:
       amount: 4
     STCraftSheetBrassT3:
-      amount: 3
+      amount: 2
 
 - type: craftRecipe
   id: newrecipe918PBMBoxCink
@@ -312,7 +312,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 5
+      amount: 4
 
 ############################################################################# 9x19
 
@@ -365,7 +365,7 @@
     CraftMaterialGunpowder:
       amount: 4
     STCraftSheetBrassT3:
-      amount: 3
+      amount: 2
 
 - type: craftRecipe
   id: newrecipe919PBMBoxCink
@@ -382,7 +382,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 5
+      amount: 4
 
 ########### 5,56
 
@@ -418,7 +418,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 5
+      amount: 4
 
 - type: craftRecipe
   id: newrecipe556WarmagBoxCink
@@ -435,7 +435,7 @@
     CraftMaterialGunpowder:
       amount: 4
     STCraftSheetBrassT3:
-      amount: 3
+      amount: 2
 
 - type: craftRecipe
   id: newrecipe556M856BoxCink
@@ -498,7 +498,6 @@
   resultProtos:
     - 725PBoxCink
     - 725PBoxCink
-    - 725PBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -515,7 +514,6 @@
   resultProtos:
     - 725PTBoxCink
     - 725PTBoxCink
-    - 725PTBoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -530,7 +528,6 @@
 - type: craftRecipe
   id: newrecipe725LRNPCBoxCink
   resultProtos:
-    - 725LRNPCBoxCink
     - 725LRNPCBoxCink
     - 725LRNPCBoxCink
   craftTime: 30
@@ -566,7 +563,6 @@
 - type: craftRecipe
   id: newrecipe739FMJBoxCink
   resultProtos:
-    - 739FMJBoxCink
     - 739FMJBoxCink
     - 739FMJBoxCink
   craftTime: 30
@@ -641,7 +637,6 @@
   resultProtos:
     - 751M80BoxCink
     - 751M80BoxCink
-    - 751M80BoxCink
   craftTime: 30
   requiredWorkbench: StalkerWorktable1
   items:
@@ -656,7 +651,6 @@
 - type: craftRecipe
   id: newrecipe751UNBoxCink
   resultProtos:
-    - 751UNBoxCink
     - 751UNBoxCink
     - 751UNBoxCink
   craftTime: 60
@@ -775,7 +769,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 3
+      amount: 2
 
 - type: craftRecipe
   id: newrecipe45ACPAPBoxCink
@@ -792,7 +786,7 @@
     CraftMaterialGunpowder:
       amount: 3
     STCraftSheetBrassT3:
-      amount: 5
+      amount: 4
 
 ########## 9x39
 


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
I standardised the ammount of boxes that crafting between T0 through T3 will give for all ammo types to be 3 as before different ammo types of the same tier gave inconsitent ammo boxes for different callibers.
## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - tweak: Standardised the results from crafting ammo boxes.
  

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Vinny-Shick

- add: Standardised the results from crafting T0 through T3 ammo.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
