### PR TITLE
fix: prevent delayed_restart shutdown hang

### DIFF
--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -192,6 +192,39 @@ namespace Content.Server.Entry
             // Stalker-Changes-End
         }
 
+        // stalker-en-changes-start: drain fire-and-forget DB writes before Dispose runs ClearAllCrashRecovery,
+        // so the Npgsql pool isn't saturated when Dispose needs it.
+        public override void Shutdown()
+        {
+            var shutdownLog = _log.GetSawmill("entrypoint");
+            shutdownLog.Info("[shutdown] EntryPoint.Shutdown entry — draining pending DB writes before Dispose");
+
+            try
+            {
+                if (_entSys.TryGetEntitySystem<_Stalker.StalkerDB.StalkerDbSystem>(out var dbSys))
+                    dbSys.FlushPendingWrites(TimeSpan.FromSeconds(10));
+            }
+            catch (Exception e)
+            {
+                shutdownLog.Error($"[shutdown] Failed to flush StalkerDbSystem: {e}");
+            }
+
+            try
+            {
+                if (_entSys.TryGetEntitySystem<_Stalker_EN.CrashRecovery.CrashRecoverySystem>(out var crSys))
+                    crSys.FlushPendingWrites(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception e)
+            {
+                shutdownLog.Error($"[shutdown] Failed to flush CrashRecoverySystem: {e}");
+            }
+
+            shutdownLog.Info("[shutdown] EntryPoint.Shutdown exit");
+
+            base.Shutdown();
+        }
+        // stalker-en-changes-end
+
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs)
         {
             base.Update(level, frameEventArgs);
@@ -216,13 +249,26 @@ namespace Content.Server.Entry
 
         protected override void Dispose(bool disposing)
         {
-            // Clear crash recovery data on graceful shutdown.
-            // On real crashes the process dies without reaching Dispose(),
-            // so snapshot data persists correctly for the next round.
+            // stalker-en-changes-start: breadcrumbs + bounded wait on ClearAllCrashRecovery
+            var shutdownLog = _log.GetSawmill("entrypoint");
+            shutdownLog.Info("[shutdown] EntryPoint.Dispose entry");
+            // stalker-en-changes-end
+
+            // On real crashes the process dies before Dispose runs, so snapshot data survives.
+            // Bounded wait — a stuck DB call would deadlock modLoader.Shutdown. // stalker-en-changes
             try
             {
                 if (_cfg.GetCVar(STCCVars.CrashRecoveryEnabled))
-                    _dbManager.ClearAllCrashRecovery().GetAwaiter().GetResult();
+                {
+                    // stalker-en-changes-start
+                    shutdownLog.Info("[shutdown] Clearing crash recovery (bounded 5s)");
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    var completed = System.Threading.Tasks.Task.Run(() => _dbManager.ClearAllCrashRecovery())
+                        .Wait(TimeSpan.FromSeconds(5));
+                    sw.Stop();
+                    shutdownLog.Info($"[shutdown] Crash recovery clear {(completed ? "completed" : "TIMED OUT")} after {sw.ElapsedMilliseconds}ms");
+                    // stalker-en-changes-end
+                }
             }
             catch (Exception e)
             {
@@ -232,16 +278,23 @@ namespace Content.Server.Entry
             var dest = _cfg.GetCVar(CCVars.DestinationFile);
             if (!string.IsNullOrEmpty(dest))
             {
+                shutdownLog.Info("[shutdown] PlayTimeTracking+DbManager shutdown (DestinationFile set)"); // stalker-en-changes
                 _playTimeTracking.Shutdown();
                 _dbManager.Shutdown();
             }
 
+            shutdownLog.Info("[shutdown] ServerApi.Shutdown"); // stalker-en-changes
             _serverApi.Shutdown();
+            shutdownLog.Info("[shutdown] StalkerServerApi.Shutdown"); // stalker-en-changes
             _stalkerServerApi.Shutdown(); // Stalker-Changes - Stalker Server API
 
             // TODO Should this be awaited?
+            shutdownLog.Info("[shutdown] DiscordLink.Shutdown"); // stalker-en-changes
             _discordLink.Shutdown();
+            shutdownLog.Info("[shutdown] DiscordChatLink.Shutdown"); // stalker-en-changes
             _discordChatLink.Shutdown();
+
+            shutdownLog.Info("[shutdown] EntryPoint.Dispose exit"); // stalker-en-changes
         }
 
         private static void LoadConfigPresets(IConfigurationManager cfg, IResourceManager res, ISawmill sawmill)

--- a/Content.Server/_Stalker/Restart/RestartSystem.cs
+++ b/Content.Server/_Stalker/Restart/RestartSystem.cs
@@ -56,7 +56,9 @@ public partial class RestartSystem : EntitySystem
 
         if (data.Comp.Time <= _timing.CurTime)
         {
+            _sawmill.Info("[shutdown] Restart timer elapsed — calling _server.Shutdown()"); // stalker-en-changes
             _server.Shutdown(null);
+            _sawmill.Info("[shutdown] _server.Shutdown() returned"); // stalker-en-changes
             return;
         }
 

--- a/Content.Server/_Stalker/StalkerDB/StalkerDbSystem.cs
+++ b/Content.Server/_Stalker/StalkerDB/StalkerDbSystem.cs
@@ -18,6 +18,11 @@ public sealed class StalkerDbSystem : EntitySystem
     [Dependency] private readonly IServerDbManager _dbManager = default!;
     [Dependency] private readonly StalkerStorageSystem _stalkerStorageSystem = default!;
 
+    // stalker-en-changes-start: track fire-and-forget DB writes so shutdown can drain them
+    private readonly ConcurrentBag<Task> _pendingDbWrites = new();
+    private ISawmill _sawmill = default!;
+    // stalker-en-changes-end
+
     public const string DefaultStalkerItems =
 """
 {
@@ -50,10 +55,63 @@ public sealed class StalkerDbSystem : EntitySystem
     {
         base.Initialize();
 
+        _sawmill = Logger.GetSawmill("stalker.db"); // stalker-en-changes
         InitializeGroupRecords();
         LoadPrototypes();
         SubscribeLocalEvent<PlayerBeforeSpawnEvent>(BeforeSpawn);
     }
+
+    // stalker-en-changes-start: drain orphaned DB writes so shutdown isn't racing the Npgsql pool
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        // Safety net; EntryPoint.Shutdown drained earlier, but writes may have occurred since.
+        FlushPendingWrites(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Call BEFORE EntryPoint.Dispose so the Npgsql pool isn't saturated when it runs ClearAllCrashRecovery.
+    /// </summary>
+    public bool FlushPendingWrites(TimeSpan timeout)
+    {
+        var pending = _pendingDbWrites.ToArray();
+        if (pending.Length == 0)
+        {
+            _sawmill.Info("[shutdown] StalkerDbSystem: no pending writes");
+            return true;
+        }
+
+        _sawmill.Info($"[shutdown] StalkerDbSystem flushing {pending.Length} pending write(s)");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var completed = false;
+        try
+        {
+            completed = Task.WhenAll(pending).Wait(timeout);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"[shutdown] StalkerDbSystem error awaiting writes: {e}");
+        }
+        sw.Stop();
+        _sawmill.Info($"[shutdown] StalkerDbSystem flush {(completed ? "completed" : "TIMED OUT")} after {sw.ElapsedMilliseconds}ms");
+        return completed;
+    }
+
+    private void TrackDbWrite(Func<Task> dbCall, string label)
+    {
+        _pendingDbWrites.Add(Task.Run(async () =>
+        {
+            try
+            {
+                await dbCall();
+            }
+            catch (Exception e)
+            {
+                _sawmill.Error($"{label}: {e}");
+            }
+        }));
+    }
+    // stalker-en-changes-end
 
     #region InventoryOperations
 
@@ -84,17 +142,17 @@ public sealed class StalkerDbSystem : EntitySystem
     public void SetInventoryJson(string login, string inputInventoryJson)
     {
         Stalkers[login] = inputInventoryJson;
-        _dbManager.SetLoginItems(login, inputInventoryJson);
+        TrackDbWrite(() => _dbManager.SetLoginItems(login, inputInventoryJson), $"SetLoginItems({login})"); // stalker-en-changes
     }
 
     public void ClearAllRepositories(string login)
     {
-        _dbManager.SetAllLoginItems(login, DefaultStalkerItems);
+        TrackDbWrite(() => _dbManager.SetAllLoginItems(login, DefaultStalkerItems), $"SetAllLoginItems({login})"); // stalker-en-changes
     }
 
     public void ClearInventoryJson(string login)
     {
-       _dbManager.SetLoginItems(login, DefaultStalkerItems);
+        TrackDbWrite(() => _dbManager.SetLoginItems(login, DefaultStalkerItems), $"ClearInventoryJson({login})"); // stalker-en-changes
     }
 
     private async Task LoadPlayer(string login, bool loadSymbols = true)

--- a/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
+++ b/Content.Server/_Stalker/StalkerRepository/StalkerRepositorySystem.cs
@@ -137,7 +137,19 @@ public sealed class StalkerRepositorySystem : EntitySystem
             InsertToRepo((uid, component), info);
         }
 
-        Task.Run(() => _sponsors.SetGiven(session.UserId, true));
+        // stalker-en-changes-start: try/catch prevents unobserved-task exceptions on DB error
+        Task.Run(() =>
+        {
+            try
+            {
+                _sponsors.SetGiven(session.UserId, true);
+            }
+            catch (Exception e)
+            {
+                _sawmill.Error($"SetGiven({session.UserId}): {e}");
+            }
+        });
+        // stalker-en-changes-end
         _stalkerStorageSystem.SaveStorage(component);
     }
 

--- a/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
+++ b/Content.Server/_Stalker/Storage/StalkerStorageSystem.cs
@@ -810,7 +810,6 @@ public sealed class StalkerStorageSystem : SharedStalkerStorageSystem
     //Сохранить инвентарь
     public void SaveStorage(StalkerRepositoryComponent _stalkerRepositoryComponent)
     {
-        Console.WriteLine("SaveStorage");
         var inventory = new AllStorageInventory();
         foreach (var item in _stalkerRepositoryComponent.ContainedItems)
         {

--- a/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
+++ b/Content.Server/_Stalker_EN/CrashRecovery/CrashRecoverySystem.cs
@@ -62,6 +62,8 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
     // Logins with unclaimed recovery data — snapshots must not overwrite these
     private readonly HashSet<string> _pendingRecoveryLogins = new();
 
+    private readonly ConcurrentBag<Task> _pendingDbWrites = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -82,14 +84,54 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
     public override void Shutdown()
     {
         base.Shutdown();
-
-        // Clear crash recovery on graceful shutdown.
-        // On real crashes, the process dies without reaching here, so data persists correctly.
-        if (_enabled)
-            _dbManager.ClearAllCrashRecovery().GetAwaiter().GetResult();
+        // Safety net; EntryPoint.Shutdown drained earlier, but writes may have occurred since.
+        FlushPendingWrites(TimeSpan.FromSeconds(5));
 
         _cfg.UnsubValueChanged(STCCVars.CrashRecoveryEnabled, v => _enabled = v);
         _cfg.UnsubValueChanged(STCCVars.CrashRecoverySaveInterval, v => _saveInterval = v);
+    }
+
+    /// <summary>
+    /// Call BEFORE EntryPoint.Dispose so the Npgsql pool isn't saturated when it runs ClearAllCrashRecovery.
+    /// </summary>
+    public bool FlushPendingWrites(TimeSpan timeout)
+    {
+        var pending = _pendingDbWrites.ToArray();
+        if (pending.Length == 0)
+        {
+            _sawmill.Info("[shutdown] CrashRecoverySystem: no pending writes");
+            return true;
+        }
+
+        _sawmill.Info($"[shutdown] CrashRecoverySystem flushing {pending.Length} pending write(s)");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var completed = false;
+        try
+        {
+            completed = Task.WhenAll(pending).Wait(timeout);
+        }
+        catch (Exception e)
+        {
+            _sawmill.Error($"[shutdown] CrashRecoverySystem error flushing writes: {e}");
+        }
+        sw.Stop();
+        _sawmill.Info($"[shutdown] CrashRecoverySystem flush {(completed ? "completed" : "TIMED OUT")} after {sw.ElapsedMilliseconds}ms");
+        return completed;
+    }
+
+    private void TrackDbWrite(Func<Task> dbCall, string label)
+    {
+        _pendingDbWrites.Add(Task.Run(async () =>
+        {
+            try
+            {
+                await dbCall();
+            }
+            catch (Exception e)
+            {
+                _sawmill.Error($"{label}: {e}");
+            }
+        }));
     }
 
     #region Game Rule Lifecycle
@@ -134,7 +176,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
             return;
 
         _sawmill.Info("Clearing all crash recovery data (round ended)");
-        _dbManager.ClearAllCrashRecovery();
+        TrackDbWrite(() => _dbManager.ClearAllCrashRecovery(), "ClearAllCrashRecovery(round-end)");
         _snapshotQueue.Clear();
         _dirtyPlayers.Clear();
         _pendingRecoveryLogins.Clear();
@@ -361,7 +403,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
 
         if (batch.Count > 0)
         {
-            _dbManager.SetCrashRecoveryBatch(batch);
+            TrackDbWrite(() => _dbManager.SetCrashRecoveryBatch(batch), $"SetCrashRecoveryBatch(force,{batch.Count})");
             _sawmill.Info($"Force snapshot saved for {batch.Count} players");
         }
         else
@@ -431,7 +473,7 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         }
 
         if (batch.Count > 0)
-            _dbManager.SetCrashRecoveryBatch(batch);
+            TrackDbWrite(() => _dbManager.SetCrashRecoveryBatch(batch), $"SetCrashRecoveryBatch(periodic,{batch.Count})");
     }
 
     /// <summary>
@@ -531,9 +573,14 @@ public sealed class CrashRecoverySystem : GameRuleSystem<CrashRecoveryRuleCompon
         {
             var data = CapturePlayerState(player);
             if (data != null)
-                _dbManager.SetCrashRecoveryBatch(new Dictionary<string, string> { { login, data } });
+            {
+                var payload = new Dictionary<string, string> { { login, data } };
+                TrackDbWrite(() => _dbManager.SetCrashRecoveryBatch(payload), $"SetCrashRecoveryBatch(immediate,{login})");
+            }
             else
-                _dbManager.SetCrashRecovery(login, null);
+            {
+                TrackDbWrite(() => _dbManager.SetCrashRecovery(login, null), $"SetCrashRecovery(clear,{login})");
+            }
 
             _dirtyPlayers.Remove(player);
         }


### PR DESCRIPTION
## What I changed

  Fixed a bug where the server would hang indefinitely after `delayed_restart` reached zero instead of exiting cleanly. The server would log `[INFO] srv: Shutting down...` 

  Root causes addressed:
  - `EntryPoint.Dispose` called `_dbManager.ClearAllCrashRecovery().GetAwaiter().GetResult()` with no timeout. This ran inside `_modLoader.Shutdown()`, before `_entityManager.Cleanup()`, so any stall here blocked the entire teardown
  sequence before entity systems could run.
  - `CrashRecoverySystem.Shutdown` had the same unbounded blocking pattern.
  - Fire-and-forget DB writes from `StalkerDbSystem.SetInventoryJson`, `ClearAllRepositories`, `ClearInventoryJson`, and several `CrashRecoverySystem` snapshot paths were not tracked or awaited, creating candidates for unobserved-task  exceptions during shutdown and pressure on the Npgsql connection pool.
  - `StalkerRepositorySystem` had `Task.Run(() => _sponsors.SetGiven(...))` with no error handling.

  Fix summary:
  - Wrapped every fire-and-forget DB write in a tracked, try/catch-guarded `Task.Run` so exceptions become sawmill logs and the tasks are drainable.
  - Added `FlushPendingWrites(TimeSpan)` to both `StalkerDbSystem` and `CrashRecoverySystem`.
  - Added an `EntryPoint.Shutdown` override that drains both pools before `EntryPoint.Dispose` runs, preventing the Npgsql pool from being saturated during the crash-recovery clear.
  - Replaced every blocking `GetAwaiter().GetResult()` in the shutdown path with `Task.Run(...).Wait(TimeSpan.FromSeconds(5))` so a hung DB never deadlocks shutdown.
  - Added breadcrumb logging across every shutdown step so the next regression can be pinpointed in seconds.
  - Removed `Console.WriteLine("SaveStorage")` debug noise.

  Tested locally: `delayed_restart 60` now produces the full shutdown breadcrumb sequence ending in `root: Goodbye.` and the process exits cleanly.

  ## Changelog

  author: @teecoding

  - fix: Fixed server hanging on shutdown after delayed_restart instead of exiting cleanly.

  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license