### PR TITLE
feat: add YAML-driven pair-level faction relation restrictions

### DIFF
--- a/Content.Server/_Stalker/Bands/BandsSystem.cs
+++ b/Content.Server/_Stalker/Bands/BandsSystem.cs
@@ -194,7 +194,7 @@ namespace Content.Server._Stalker.Bands
                 playerFaction = _factionRelations.ResolvePrimary(playerFaction);
 
             var relationsState = _factionRelations.BuildUiState();
-            var hideRelationsTab = !string.IsNullOrEmpty(playerFaction) && _factionRelations.IsFactionRestricted(playerFaction);
+            var hideRelationsTab = !string.IsNullOrEmpty(playerFaction) && _factionRelations.HidesRelationsUi(playerFaction);
 
             var allFactions = new List<string>();
             foreach (var f in relationsState.FactionIds)

--- a/Content.Server/_Stalker_EN/FactionRelations/Commands/STFactionRelationCommand.cs
+++ b/Content.Server/_Stalker_EN/FactionRelations/Commands/STFactionRelationCommand.cs
@@ -106,6 +106,9 @@ public sealed class STFactionRelationCommand : IConsoleCommand
             return;
         }
 
+        if (system.IsRelationRestricted(factionA, factionB, relation))
+            shell.WriteLine($"Note: {relation} is YAML-forbidden for {factionA} <-> {factionB}. Overriding as admin.");
+
         system.SetRelation(factionA, factionB, relation, broadcast: broadcast);
         shell.WriteLine($"Set relation {factionA} <-> {factionB} to {relation}{(broadcast ? " (announced)" : " (silent)")}");
     }

--- a/Content.Server/_Stalker_EN/FactionRelations/STFactionRelationsCartridgeSystem.cs
+++ b/Content.Server/_Stalker_EN/FactionRelations/STFactionRelationsCartridgeSystem.cs
@@ -89,6 +89,11 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
     private HashSet<string> _cachedHiddenFactions = new();
 
     /// <summary>
+    /// Pair-level forbidden relation transitions. Key: normalized pair.
+    /// </summary>
+    private Dictionary<(string, string), HashSet<STFactionRelationType>> _cachedRelationRestrictions = new();
+
+    /// <summary>
     /// Tracks loaders (PDAs) that currently have the faction relations cartridge active.
     /// Only these receive broadcast UI updates.
     /// </summary>
@@ -214,6 +219,7 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         _primaryToAliases = new Dictionary<string, List<string>>();
         _cachedRestrictedFactions = new HashSet<string>();
         _cachedHiddenFactions = new HashSet<string>();
+        _cachedRelationRestrictions = new Dictionary<(string, string), HashSet<STFactionRelationType>>();
         _cachedFactionIds = null;
 
         if (!_protoManager.TryIndex(DefaultsProtoId, out var proto))
@@ -239,6 +245,22 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         {
             var key = STFactionRelationHelpers.NormalizePair(rel.FactionA, rel.FactionB);
             _defaultsCache[key] = rel.Relation;
+        }
+
+        foreach (var restriction in proto.RelationRestrictions)
+        {
+            var a = _aliasToPrimary.GetValueOrDefault(restriction.FactionA, restriction.FactionA);
+            var b = _aliasToPrimary.GetValueOrDefault(restriction.FactionB, restriction.FactionB);
+            if (a == b)
+                continue;
+            var key = STFactionRelationHelpers.NormalizePair(a, b);
+            if (!_cachedRelationRestrictions.TryGetValue(key, out var set))
+            {
+                set = new HashSet<STFactionRelationType>();
+                _cachedRelationRestrictions[key] = set;
+            }
+            foreach (var forbidden in restriction.Forbidden)
+                set.Add(forbidden);
         }
     }
 
@@ -470,6 +492,28 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         return _cachedHiddenFactions.Contains(faction);
     }
 
+    /// <summary>
+    /// Returns true if the UI gate for this faction's members should be hidden.
+    /// Currently equivalent to <see cref="IsFactionRestricted"/>; kept as a distinct name
+    /// so future factions can hide the tab without taking the all-or-nothing lock.
+    /// </summary>
+    public bool HidesRelationsUi(string faction)
+    {
+        return IsFactionRestricted(faction);
+    }
+
+    /// <summary>
+    /// Returns true if the given relation transition is forbidden between this pair by YAML config.
+    /// </summary>
+    public bool IsRelationRestricted(string factionA, string factionB, STFactionRelationType relation)
+    {
+        factionA = ResolvePrimary(factionA);
+        factionB = ResolvePrimary(factionB);
+        var key = STFactionRelationHelpers.NormalizePair(factionA, factionB);
+        return _cachedRelationRestrictions.TryGetValue(key, out var forbidden)
+               && forbidden.Contains(relation);
+    }
+
     #endregion
 
     #region Relation Changes
@@ -505,6 +549,9 @@ public sealed class STFactionRelationsCartridgeSystem : EntitySystem
         var currentRelation = GetRelation(initiatingFaction, targetFaction);
         if (currentRelation == proposedRelation)
             return STFactionRelationChangeResult.SameRelation;
+
+        if (IsRelationRestricted(initiatingFaction, targetFaction, proposedRelation))
+            return STFactionRelationChangeResult.RestrictedRelation;
 
         var key = STFactionRelationHelpers.NormalizePair(initiatingFaction, targetFaction);
         if (_pairCooldowns.TryGetValue(key, out var expiry) && expiry > _timing.CurTime)

--- a/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationChangeResult.cs
+++ b/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationChangeResult.cs
@@ -52,4 +52,9 @@ public enum STFactionRelationChangeResult : byte
     /// The target faction is restricted and can only be changed by admins.
     /// </summary>
     RestrictedFaction,
+
+    /// <summary>
+    /// The proposed relation is forbidden for this pair by YAML configuration.
+    /// </summary>
+    RestrictedRelation,
 }

--- a/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationDefaultsPrototype.cs
+++ b/Content.Shared/_Stalker_EN/FactionRelations/STFactionRelationDefaultsPrototype.cs
@@ -65,6 +65,13 @@ public sealed class STFactionRelationDefaultsPrototype : IPrototype
     /// </summary>
     [DataField]
     public Dictionary<string, string> DisplayNames { get; } = new();
+
+    /// <summary>
+    /// Pairwise relation restrictions. Blocks players from setting the listed relations
+    /// between the given pair. Pair order does not matter. Admin commands bypass these.
+    /// </summary>
+    [DataField]
+    public List<STFactionRelationRestriction> RelationRestrictions { get; } = new();
 }
 
 /// <summary>
@@ -81,4 +88,21 @@ public sealed partial class STFactionRelationDefault
 
     [DataField(required: true)]
     public STFactionRelationType Relation { get; set; }
+}
+
+/// <summary>
+/// A pair-specific set of relation transitions that players cannot initiate.
+/// </summary>
+[DataDefinition]
+public sealed partial class STFactionRelationRestriction
+{
+    [DataField(required: true)]
+    public string FactionA { get; set; } = string.Empty;
+
+    [DataField(required: true)]
+    public string FactionB { get; set; } = string.Empty;
+
+    /// <summary>Relation states that cannot be set between this pair.</summary>
+    [DataField(required: true)]
+    public List<STFactionRelationType> Forbidden { get; set; } = new();
 }

--- a/Resources/Locale/ru-RU/_Stalker_EN/faction-relations.ftl
+++ b/Resources/Locale/ru-RU/_Stalker_EN/faction-relations.ftl
@@ -167,3 +167,6 @@ bands-managing-window-relation-declare-button = Объявить
 bands-managing-window-relation-propose-button = Предложить
 bands-managing-window-relation-confirm-free = Подтвердить?
 bands-managing-window-relation-broadcast = Предложение радиовещания
+
+# Error feedback (reserved for future UI hookup)
+st-faction-relations-error-restricted-relation = Эта фракция не может установить такие отношения с выбранной стороной.

--- a/Resources/Prototypes/_Stalker_EN/FactionRelations/defaults.yml
+++ b/Resources/Prototypes/_Stalker_EN/FactionRelations/defaults.yml
@@ -45,6 +45,22 @@
     - UN
   displayNames:
     ClearSky: Clear Sky
+  # Pairwise relation transitions players cannot initiate. Pair order is ignored.
+  # Admin commands bypass these restrictions.
+  # Note: if a faction is also in `restrictedFactions`, that all-or-nothing lock wins;
+  # these entries act as self-documentation and a fallback if the faction is removed
+  # from `restrictedFactions` later.
+  relationRestrictions:
+    # Monolith zealots do not negotiate: only War is a legal relation with them.
+    - { factionA: Monolith, factionB: Loners,      forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Freedom,     forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Bandits,     forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Duty,        forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Ecologist,   forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Mercenaries, forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Military,    forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: ClearSky,    forbidden: [Alliance, Neutral, Hostile] }
+    - { factionA: Monolith, factionB: Renegades,   forbidden: [Alliance, Neutral, Hostile] }
   relations:
     # MONOLITH
     - { factionA: Monolith, factionB: Loners, relation: War }


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Added YAML-driven pair-level restrictions for the faction relations system. Previously the only way to lock relations was the all-or-nothing `restrictedFactions` list, which blocked every change involving a listed faction. Now specific relation transitions can be forbidden per pair via a new `relationRestrictions` field on `stFactionRelationDefaults`.

**New config shape** (in `Resources/Prototypes/_Stalker_EN/FactionRelations/defaults.yml`):

```yaml
relationRestrictions:
  - { factionA: Duty, factionB: Freedom, forbidden: [Alliance] }
  - { factionA: Bandits, factionB: Ecologist, forbidden: [Alliance, Neutral] }
```

Pair order is ignored, aliases are resolved before the check, and admin commands bypass with an advisory line so staff know they are overriding a YAML rule.

## Changelog

author: @teecoding

- add: Faction relations can now forbid specific transitions between specific faction pairs via YAML config (for example, two factions that cannot make peace).
- tweak: Monolith relation locks are now expressed explicitly in YAML as "War only" instead of relying purely on the all-or-nothing restricted-factions list.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
