### PR TITLE
fix: prevent PDA messenger replies from leaking across chats

### DIFF
--- a/Content.Client/_Stalker_EN/PdaMessenger/STMessengerChannelPage.xaml.cs
+++ b/Content.Client/_Stalker_EN/PdaMessenger/STMessengerChannelPage.xaml.cs
@@ -46,6 +46,13 @@ public sealed partial class STMessengerChannelPage : BoxContainer, IOfferLinkCli
 
     public void SetChatId(string chatId)
     {
+        if (chatId != _chatId)
+        {
+            MessageList.DisposeAllChildren();
+            _lastMessageCount = 0;
+            _lastChatId = string.Empty;
+            ChatTitle.Text = string.Empty;
+        }
         _chatId = chatId;
     }
 
@@ -61,11 +68,15 @@ public sealed partial class STMessengerChannelPage : BoxContainer, IOfferLinkCli
             _lastChatId = chat.Id;
         }
 
+        // Bind each reply handler to the chat the message was rendered under, so a
+        // stale entry from a previous chat can't fire OnReply with the current _chatId.
+        var renderedChatId = chat.Id;
+
         // Append only new messages
         for (var i = _lastMessageCount; i < chat.Messages.Count; i++)
         {
             var entry = new STMessengerMessageEntry(chat.Messages[i]);
-            entry.OnReply += (msgId, snippet) => OnReply?.Invoke(_chatId, msgId, snippet);
+            entry.OnReply += (msgId, snippet) => OnReply?.Invoke(renderedChatId, msgId, snippet);
             MessageList.AddChild(entry);
         }
 

--- a/Content.Client/_Stalker_EN/PdaMessenger/STMessengerUi.cs
+++ b/Content.Client/_Stalker_EN/PdaMessenger/STMessengerUi.cs
@@ -122,6 +122,8 @@ public sealed partial class STMessengerUi : UIFragment
 
         _composePage.OnBack += () =>
         {
+            _replyToId = null;
+            _replySnippet = null;
             _composePage.Visible = false;
             _channelPage!.Visible = true;
         };
@@ -195,6 +197,8 @@ public sealed partial class STMessengerUi : UIFragment
 
     private void NavigateToChat(string chatId)
     {
+        _replyToId = null;
+        _replySnippet = null;
         _currentChatId = chatId;
 
         // Tell server which chat we're viewing (for lazy message loading)
@@ -208,6 +212,8 @@ public sealed partial class STMessengerUi : UIFragment
 
     private void NavigateToMain()
     {
+        _replyToId = null;
+        _replySnippet = null;
         _currentChatId = null;
         _channelPage!.Visible = false;
         _composePage!.Visible = false;

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -385,9 +385,15 @@ public sealed partial class STMessengerSystem : EntitySystem
         }
 
         string? replySnippet = null;
+        uint? effectiveReplyToId = null;
         if (replyToId is { } replyId)
         {
             replySnippet = FindReplySnippet(chatId, isDm, server, replyId);
+            // Drop the reply attribution if the referenced message doesn't exist in the target chat.
+            // This prevents a stale client-side replyToId (from a different chat, where message IDs
+            // can collide) from landing on an unrelated post.
+            if (replySnippet is not null)
+                effectiveReplyToId = replyId;
         }
 
         List<STMessengerMessage> chatMessages;
@@ -462,7 +468,7 @@ public sealed partial class STMessengerSystem : EntitySystem
             displayName,
             content,
             _timing.CurTime,
-            replyToId,
+            effectiveReplyToId,
             replySnippet,
             senderFaction,
             senderRankIcon);


### PR DESCRIPTION
## What I changed
                                                                                                                                                                                                                                             
  Fixed a bug where sending a PDA messenger DM could land in a public channel as a reply to an unrelated post.                                                                                                                               
                                                                                                                                                                                                                                             
  Root cause: the channel page kept stale message entries on screen after switching chats, and each Reply button read the current chat ID at click time. Clicking Reply on a stale entry right after navigating fired the reply with the new 
  chat ID plus the old message's ID - and since message IDs are per-chat and collide, the server matched a different message in the new chat.
                                                                                                                                                                                                                                             
  Fixes:                                                                                                                                                                                                                                     
  - `STMessengerChannelPage`: dispose entries when the chat changes; bind Reply handlers to the rendered chat's ID, not the mutable field.
  - `STMessengerUi`: clear reply state on every navigation and on compose back.                                                                                                                                                              
  - `STMessengerSystem`: drop `replyToId` server-side when the referenced message isn't in the target chat.                                                                                                                                  
                                                                                                                                                                                                                                             
  ## Changelog                                                                                                                                                                                                                               
                                                                                                                                                                                                                                             
  author: @teecoding                                                                                                                                                                                                                         
         
  - fix: Fixed PDA messenger sometimes sending DMs to the wrong chat as replies to unrelated messages.                                                                                                                                       
                                         
  <!-- Put X - [X]: -->                                                                                                                                                                                                                      
  ## Make sure you check and agree to the following
  - [X] Yes, I ran my code and tested that the changes worked                                                                                                                                                                                
  - [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
  - [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).                                                                                     
  - [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license     