### PR TITLE
Fixes artifact prices in eco

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -6,10 +6,10 @@
     ZoneArtifactFireball: 680
     ZoneArtifactEye: 1020
     ZoneArtifactFlame: 2040
-    ZoneArtifactBunch: 1775
+    ZoneArtifactBunch: 2375
     ZoneArtifactRock: 2040
     ZoneArtifactSun: 2760
-    ZoneArtifactRoot: 3800
+    ZoneArtifactRoot: 4080
     ZoneArtifactConflagration: 1020
     # Thermal group - 2
     ZoneArtifactCristall: 4080
@@ -19,14 +19,14 @@
     ZoneArtifactBattery: 1020
     ZoneArtifactFlash: 2040
     ZoneArtifactAccumulator: 2040
-    ZoneArtifactDiamond: 2760
+    ZoneArtifactDiamond: 3690
     ZoneArtifactCharger: 1020
     ArtMoon: 4080
     ZoneArtifactTesla: 6120
     ZoneArtifactIce: 8160
     # Gravity group - 1
     ArtMedusa: 680
-    ZoneArtifactWhirlwind: 900
+    ZoneArtifactWhirlwind: 1020
     ZoneArtifactFlower: 1020
     ZoneArtifactNightStar: 4080
     ZoneArtifactPebble: 680
@@ -39,15 +39,15 @@
     ZoneArtifactFloodlight: 1020
     ZoneArtifactGravi: 2040
     ZoneArtifactGoldfish: 8160
-    ZoneArtifactSpring: 6120
+    ZoneArtifactSpring: 4500
     ZoneArtifactFocus: 6120
     ZoneArtifactStuntman: 8160
     ZoneArtifactDistorter: 8160
     ZoneArtifactSoul: 6120
-    ZoneArtifactCompass: 3375
-    ZoneArtifactCrucifix: 3990
-    ZoneArtifactThorn: 2390
-    ZoneArtifactArf: 2390
+    ZoneArtifactCompass: 4500
+    ZoneArtifactCrucifix: 5250
+    ZoneArtifactThorn: 3200
+    ZoneArtifactArf: 3200
     # Acidic group - 1
     ZoneArtifactToxic: 610
     ZoneArtifactCytoplasm: 2040

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/freedom.yml
@@ -28,7 +28,7 @@
     ArtMedusa: 810
     ZoneArtifactFlower: 1215
     ZoneArtifactNightStar: 4860
-    ZoneArtifactWhirlwind: 1000
+    ZoneArtifactWhirlwind: 1215
     ZoneArtifactPebble: 810
     ZoneArtifactRosin: 1215
     ZoneArtifactStoneCube: 1825

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/NPCShops/Barman.yml
@@ -29,7 +29,7 @@
     ArtMedusa: 540
     ZoneArtifactFlower: 810
     ZoneArtifactNightStar: 3240
-    ZoneArtifactWhirlwind: 500
+    ZoneArtifactWhirlwind: 810
     ZoneArtifactPebble: 540
     ZoneArtifactRosin: 810
     ZoneArtifactStoneCube: 1215


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->

Newer artifacts are for some reason priced extremely weirdly currently and are not actually 1.25x the rate of barman at Eco. They were appropriately rated for Freedom though. This fixes that

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @AlesterPherrer

- tweak: Fixed inconsistent artifact sale rates with Ecologists with the newer artifacts

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
