### PR TITLE
Monolith now always see their fellow mono's names proper in their special radio comms

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -78,10 +78,15 @@ public sealed class RadioSystem : EntitySystem
 
         var evt = new TransformSpeakerNameEvent(messageSource, MetaData(messageSource).EntityName);
         RaiseLocalEvent(messageSource, evt);
-
+        // stalker-en changes start - This forces Monolith voices on the monolith channel always to show hopefully their real name :pray:
         var name = evt.VoiceName;
-        name = FormattedMessage.EscapeText(name);
-
+        if (channel.ID == "Monolith") 
+        {
+            name = Name(messageSource);
+        }
+        // stalker-en changes end 
+            name = FormattedMessage.EscapeText(name);
+        
         SpeechVerbPrototype speech;
         if (evt.SpeechVerb != null && _prototype.Resolve(evt.SpeechVerb, out var evntProto))
             speech = evntProto;


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
 Made monolith voice comms always show their proper name since its monolith magical comms 
 
<img width="375" height="68" alt="image" src="https://github.com/user-attachments/assets/9450e39a-e7c7-4ab7-b640-b1cc77456ed5" />

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @nathan736 
- tweak: Monolith know who they are talking to in their minds

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
