### PR TITLE
Add pillboxes to eco

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
@@ -805,12 +805,12 @@
         - id: MedkitAI2
         - id: MedkitAI2
         - id: MedkitAI2
-        - id: MedkitAI2
-        - id: MedkitAI2
-        - id: MedkitAI2
-        - id: MedkitAI2
-        - id: MedkitAI2
-        - id: MedkitAI2
+        - id: MedkitAI2 # EN
+        - id: MedkitAI2 # EN
+        - id: MedkitAI2 # EN
+        - id: MedkitAI2 # EN
+        - id: MedkitAI2 # EN
+        - id: MedkitAI2 # EN
         - id: Defibrillator
       sound:
         path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Economy/crates.yml
@@ -805,6 +805,12 @@
         - id: MedkitAI2
         - id: MedkitAI2
         - id: MedkitAI2
+        - id: MedkitAI2
+        - id: MedkitAI2
+        - id: MedkitAI2
+        - id: MedkitAI2
+        - id: MedkitAI2
+        - id: MedkitAI2
         - id: Defibrillator
       sound:
         path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -191,13 +191,13 @@
         STPillboxProbud: 300
         STPillboxAntirad: 200
         STPillboxShiza: 6000
-        # Crates
+        # Crates - 10% discount over individual medkits
         SaviorCrate: 2250
-        BulkArmyMedCrate: 2500
+        BulkArmyMedCrate: 2250
         #ArmySciCrate: 4500
-        BulkScienceCrate: 4375
-        BulkEliteCrate: 6000
-        BulkLARCrate: 7800
+        BulkScienceCrate: 3950
+        BulkEliteCrate: 5400
+        BulkLARCrate: 7000
 
     - name: shop-category-provisions
       priority: 5

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -300,6 +300,7 @@
     - name: shop-category-utilities
       priority: 10
       items:
+        HandLabeler: 75
         HuntingKnife: 250
         STCombatKnife: 25
         BoxZiptie: 50

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -192,7 +192,7 @@
         STPillboxAntirad: 200
         STPillboxShiza: 6000
         # Crates - 10% discount over individual medkits
-        SaviorCrate: 2250
+        SaviorCrate: 2150
         BulkArmyMedCrate: 2250
         #ArmySciCrate: 4500
         BulkScienceCrate: 3950

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -187,6 +187,10 @@
         Defibrillator: 700
         MedkitElite: 500
         MedkitLAR: 650
+        # pill bottles, slightly cheaper than best NPC vendor
+        STPillboxProbud: 300
+        STPillboxAntirad: 200
+        STPillboxShiza: 6000
         # Crates
         SaviorCrate: 2250
         BulkArmyMedCrate: 2500

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -300,6 +300,7 @@
     - name: shop-category-utilities
       priority: 10
       items:
+        PillCanister: 100
         HandLabeler: 75
         HuntingKnife: 250
         STCombatKnife: 25

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/ecologist.yml
@@ -191,13 +191,13 @@
         STPillboxProbud: 300
         STPillboxAntirad: 200
         STPillboxShiza: 6000
-        # Crates - 10% discount over individual medkits
+        # Crates
         SaviorCrate: 2150
-        BulkArmyMedCrate: 2250
+        BulkArmyMedCrate: 2500
         #ArmySciCrate: 4500
         BulkScienceCrate: 3950
-        BulkEliteCrate: 5400
-        BulkLARCrate: 7000
+        BulkEliteCrate: 6000
+        BulkLARCrate: 7800
 
     - name: shop-category-provisions
       priority: 5


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
- Rescue crate now has 6 more AI-2s so it is full again after defib got made smaller
- Bulk med boxes have a 10% discount over buying the individual items
- Added pill boxes to the eco shop, for SLIGHTLY cheaper than the NPC vendor prices
- Added hand labeler, we are an RP faction and that is super useful for that.

Old Rescue kit:
<img width="206" height="175" alt="image" src="https://github.com/user-attachments/assets/f3cc0097-4e7f-44e9-8c77-f7680e0d5e0e" />

New Rescue kit:
<img width="210" height="187" alt="image" src="https://github.com/user-attachments/assets/1ac169b0-97fc-4916-b5fd-eae2792de859" />



## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Cassandra

- add: Eco now carries full pillboxes too, not just individual pills
- tweak: Rescue Pack now is full again

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
