### PR TITLE
add artifact slots to eco coat

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -436,7 +436,7 @@
       coefficients:
         Caustic: 0.75
   - type: GrantsArtifactSlots # Stalker EN
-    slots: 5
+    slots: 3
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabSeniorResearcher]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -435,6 +435,8 @@
     modifiers:
       coefficients:
         Caustic: 0.75
+  - type: GrantsArtifactSlots # Stalker EN
+    slots: 5
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabSeniorResearcher]

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
@@ -441,6 +441,8 @@
     sprite: _Stalker/Objects/Clothing/outerClothing/jacket_sci.rsi
   - type: Clothing
     sprite: _Stalker/Objects/Clothing/outerClothing/jacket_sci.rsi
+  - type: GrantsArtifactSlots # Stalker EN
+    slots: 3
 
 - type: entity
   parent: STClothingHeadHatBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
@@ -377,7 +377,7 @@
   - type: Contraband # EN
     severity: Monolith
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 2 # EN
 
 - type: entity
   parent: STClothingHeadHatHoodBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
@@ -377,7 +377,7 @@
   - type: Contraband # EN
     severity: Monolith
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
 
 - type: entity
   parent: STClothingHeadHatHoodBase
@@ -442,7 +442,7 @@
   - type: Clothing
     sprite: _Stalker/Objects/Clothing/outerClothing/jacket_sci.rsi
   - type: GrantsArtifactSlots # Stalker EN
-    slots: 3
+    slots: 2
 
 - type: entity
   parent: STClothingHeadHatBase


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
The senior researcher coat now has 5 artifact slots. This is the one the Dean spawns with.

The blue coat now has 3 slots. This is the one that may be selected by all scientists to spawn with.

Why this is a good idea:
<img width="509" height="374" alt="image" src="https://github.com/user-attachments/assets/66c6d826-5448-40a9-830f-3e0eaa0cd53f" />
- i hate seeing the red icons
- itd be funny
- it makes sense
- it wouldnt be busted (the fucking thing dosnt have any armor anyways)
- Allows us to research artifact effects without having armor muddy the results

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Cassandra

- tweak: Eco lab coat now adds artifact slots

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
