### PR TITLE
fix: messenger news broadcast amplification

### DIFF
--- a/Content.Server/_Stalker_EN/News/STNewsSystem.cs
+++ b/Content.Server/_Stalker_EN/News/STNewsSystem.cs
@@ -66,6 +66,14 @@ public sealed partial class STNewsSystem : EntitySystem
     /// <summary>Cached summary list, invalidated on publish/delete/comment. Avoids re-running regex strip on every UI open.</summary>
     private List<STNewsArticleSummary>? _cachedSummaries;
 
+    /// <summary>
+    /// Set by publish/delete/comment paths to request a UI broadcast on the next <see cref="Update"/> tick.
+    /// Coalesces bursts of mutation events into a single fan-out (vs. the prior pattern of one
+    /// full BroadcastUiUpdate per event). Distinct from <see cref="_reactionBroadcastPending"/>,
+    /// which has its own 1.5s debounce window for reaction-toggle traffic.
+    /// </summary>
+    private bool _broadcastPending;
+
     private WebhookIdentifier? _webhookId;
     private bool _cacheReady;
 
@@ -100,13 +108,17 @@ public sealed partial class STNewsSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        if (!_reactionBroadcastPending)
+        var reactionsReady = _reactionBroadcastPending && _timing.CurTime >= _nextReactionBroadcast;
+
+        if (!_broadcastPending && !reactionsReady)
             return;
 
-        if (_timing.CurTime < _nextReactionBroadcast)
-            return;
+        // Single fan-out covers both pending paths; clearing both flags prevents a redundant
+        // second broadcast in the same tick.
+        _broadcastPending = false;
+        if (reactionsReady)
+            _reactionBroadcastPending = false;
 
-        _reactionBroadcastPending = false;
         BroadcastUiUpdate();
     }
 
@@ -291,6 +303,7 @@ public sealed partial class STNewsSystem : EntitySystem
         _allLoaders.Clear();
         _cachedSummaries = null;
         _reactionBroadcastPending = false;
+        _broadcastPending = false;
     }
 
     #endregion
@@ -456,7 +469,7 @@ public sealed partial class STNewsSystem : EntitySystem
         DeleteArticleAsync(delete.ArticleId);
         DeleteReactionsForArticleAsync(delete.ArticleId);
 
-        BroadcastUiUpdate();
+        _broadcastPending = true;
     }
 
     private void OnPostComment(STNewsPostCommentEvent comment, CartridgeMessageEvent args)
@@ -656,7 +669,7 @@ public sealed partial class STNewsSystem : EntitySystem
             _cachedSummaries = null;
 
             SendDiscordArticle(article);
-            BroadcastUiUpdate();
+            _broadcastPending = true;
             SendNotifications(article);
         }
         catch (Exception e)
@@ -712,8 +725,9 @@ public sealed partial class STNewsSystem : EntitySystem
             list.Add(comment);
             _cachedSummaries = null; // Comment count changed
 
-            // Broadcast updates all active viewers, including those viewing this article
-            BroadcastUiUpdate();
+            // Broadcast updates all active viewers, including those viewing this article.
+            // Coalesced via _broadcastPending so a burst of comments collapses to one fan-out per tick.
+            _broadcastPending = true;
         }
         catch (Exception e)
         {

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.Database.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.Database.cs
@@ -141,7 +141,7 @@ public sealed partial class STMessengerSystem
             // Refresh all active messenger UIs so contacts see this player's current faction.
             // Done here (after DB loads complete) rather than in InitializeMessengerForPda
             // to avoid a wasted broadcast before contacts are populated.
-            BroadcastUiUpdate();
+            MarkBroadcastPending(null);
         }
         catch (Exception ex)
         {

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -140,6 +140,39 @@ public sealed partial class STMessengerSystem : EntitySystem
     /// </summary>
     private List<STMessengerChannelPrototype> _sortedChannels = new();
 
+    /// <summary>
+    /// Coalesces multiple <see cref="BroadcastUiUpdate"/> calls in the same tick into a single
+    /// flush in <see cref="Update"/>. Without this, every message/contact event amplifies into
+    /// O(active_loaders * contacts) work per event.
+    /// </summary>
+    private bool _broadcastPending;
+
+    /// <summary>
+    /// Chat ID filter for the next coalesced broadcast (mirrors <see cref="BroadcastUiUpdate"/>'s
+    /// <c>changedChatId</c> parameter). Null means "no filter / broadcast to all loaders". Once
+    /// any pending event drops the filter (or two events disagree on the chat id), it stays null.
+    /// </summary>
+    private string? _broadcastChatHint;
+
+    /// <summary>
+    /// Tracks whether <see cref="_broadcastChatHint"/> is meaningful for the current pending
+    /// broadcast — distinguishes "explicitly null filter (broadcast to all)" from the freshly
+    /// cleared state.
+    /// </summary>
+    private bool _broadcastChatHintInitialized;
+
+    /// <summary>
+    /// Per-broadcast resolution cache for contact factions. Keyed by (userId, charName, alwaysHideClearSky).
+    /// Cleared at the start of each coalesced broadcast so values stay fresh across ticks but are
+    /// reused across loaders that share the same contact within a single broadcast.
+    /// </summary>
+    private readonly Dictionary<(Guid, string, bool), string?> _factionResolveCache = new();
+
+    /// <summary>
+    /// Per-broadcast resolution cache for contact rank icons. See <see cref="_factionResolveCache"/>.
+    /// </summary>
+    private readonly Dictionary<(Guid, string), string?> _rankResolveCache = new();
+
     private WebhookIdentifier? _webhookIdentifier;
 
     /// <summary>
@@ -179,6 +212,45 @@ public sealed partial class STMessengerSystem : EntitySystem
     {
         base.Shutdown();
         _config.UnsubValueChanged(STCCVars.MessengerDiscordWebhook, OnWebhookChanged);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_broadcastPending)
+            return;
+
+        var hint = _broadcastChatHint;
+        _broadcastPending = false;
+        _broadcastChatHint = null;
+        _broadcastChatHintInitialized = false;
+
+        // Per-broadcast resolution cache: shared across all loaders processed in this flush.
+        _factionResolveCache.Clear();
+        _rankResolveCache.Clear();
+
+        BroadcastUiUpdate(hint);
+    }
+
+    /// <summary>
+    /// Marks a UI broadcast as pending; the actual fan-out runs once at the next <see cref="Update"/>.
+    /// Multiple calls in the same tick collapse into one broadcast, and conflicting chat-id filters
+    /// widen to "all" (null hint).
+    /// </summary>
+    private void MarkBroadcastPending(string? chatId)
+    {
+        if (!_broadcastPending)
+        {
+            _broadcastPending = true;
+            _broadcastChatHint = chatId;
+            _broadcastChatHintInitialized = true;
+            return;
+        }
+
+        // Already pending — widen the filter if the new event disagrees with the prior hint.
+        if (_broadcastChatHintInitialized && _broadcastChatHint != chatId)
+            _broadcastChatHint = null;
     }
 
     private void OnWebhookChanged(string value)
@@ -579,7 +651,7 @@ public sealed partial class STMessengerSystem : EntitySystem
             }
         }
 
-        BroadcastUiUpdate(chatId);
+        MarkBroadcastPending(chatId);
     }
 
     /// <summary>
@@ -819,7 +891,7 @@ public sealed partial class STMessengerSystem : EntitySystem
             $"{ToPrettyString(args.Actor):player} added messenger contact " +
             $"{contactIdentity.CharName} (ID: {add.MessengerId})");
 
-        BroadcastUiUpdate();
+        MarkBroadcastPending(null);
     }
 
     private void OnRemoveContact(
@@ -1040,8 +1112,10 @@ public sealed partial class STMessengerSystem : EntitySystem
         {
             // Fresh-resolve faction for online contacts so faction changes propagate; fall back to cached
             // for offline. alwaysHideClearSky keeps CS members pinned to Loners on contact lists.
+            // Cached variant: when multiple loaders share this contact within a single coalesced
+            // broadcast (see Update + _factionResolveCache), we resolve each contact once.
             var contactKey = (contactEntry.UserId, contactEntry.CharacterName);
-            var currentFaction = ResolveContactFaction(contactKey, alwaysHideClearSky: true);
+            var currentFaction = ResolveContactFactionCached(contactKey, alwaysHideClearSky: true);
             if (currentFaction is not null && currentFaction != contactEntry.FactionName)
             {
                 contactEntry.FactionName = currentFaction;
@@ -1049,7 +1123,7 @@ public sealed partial class STMessengerSystem : EntitySystem
                     contactEntry.UserId, contactEntry.CharacterName, currentFaction);
             }
 
-            var rankIcon = ResolveContactRankIcon(contactKey);
+            var rankIcon = ResolveContactRankIconCached(contactKey);
 
             contactInfos.Add(new STMessengerContactInfo(
                 contactEntry.CharacterName,
@@ -1259,6 +1333,11 @@ public sealed partial class STMessengerSystem : EntitySystem
         _messengerPdas.Clear();
         _anonymousPseudonyms.Clear();
         _usedPseudonyms.Clear();
+        _factionResolveCache.Clear();
+        _rankResolveCache.Clear();
+        _broadcastPending = false;
+        _broadcastChatHint = null;
+        _broadcastChatHintInitialized = false;
         // Do NOT clear _messengerIdCache or _characterToMessengerId — IDs persist across rounds
 
         foreach (var proto in _sortedChannels)
@@ -1292,6 +1371,38 @@ public sealed partial class STMessengerSystem : EntitySystem
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// Per-broadcast cached variant of <see cref="ResolveContactRankIcon"/>. Used inside
+    /// <see cref="BuildUiState"/> so multiple loaders sharing the same contact within a coalesced
+    /// broadcast resolve that contact's rank only once. Cache is cleared at the start of each
+    /// coalesced broadcast in <see cref="Update"/>.
+    /// </summary>
+    private string? ResolveContactRankIconCached((Guid UserId, string CharName) contactKey)
+    {
+        var cacheKey = (contactKey.UserId, contactKey.CharName);
+        if (_rankResolveCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
+        var live = ResolveContactRankIcon(contactKey);
+        _rankResolveCache[cacheKey] = live;
+        return live;
+    }
+
+    /// <summary>
+    /// Per-broadcast cached variant of <see cref="ResolveContactFaction"/>. See
+    /// <see cref="ResolveContactRankIconCached"/> for the cache lifecycle.
+    /// </summary>
+    private string? ResolveContactFactionCached((Guid UserId, string CharName) contactKey, bool alwaysHideClearSky = false)
+    {
+        var cacheKey = (contactKey.UserId, contactKey.CharName, alwaysHideClearSky);
+        if (_factionResolveCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
+        var live = ResolveContactFaction(contactKey, alwaysHideClearSky);
+        _factionResolveCache[cacheKey] = live;
+        return live;
+    }
 
     /// <summary>
     /// Resolves the current rank icon of an online contact by looking up their session's attached entity.


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed

Two server-side perf fixes that address a broadcast-amplification issue in the PDA Messenger and News cartridges:

Note: this needs live testing on a populated server (10+ messenger users with contacts, sustained chat) to confirm the load drop in practice. Static repro is hard.

## Changelog

author: @teecoding

- fix: Reduced server load when many players use the PDA Messenger or News cartridge at once.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license