### PR TITLE
Up Artifact Slots by 1 on Armor Globally

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -436,7 +436,7 @@
       coefficients:
         Caustic: 0.75
   - type: GrantsArtifactSlots # Stalker EN
-    slots: 3
+    slots: 4
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabSeniorResearcher]

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/ArmorSoft.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/ArmorSoft.yml
@@ -23,6 +23,6 @@
         Slash: 0.85
         Piercing: 0.80
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.85

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Coat.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Coat.yml
@@ -31,7 +31,7 @@
         Heat: 0.95
         Radiation: 0.9
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: Storage
     maxItemSize: Normal
     blacklist:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/Jacket.yml
@@ -29,7 +29,7 @@
         Compression: 0.95
         Radiation: 0.9
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: Storage
     maxItemSize: Normal
     grid:
@@ -377,7 +377,7 @@
   - type: Contraband # EN
     severity: Monolith
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
 
 - type: entity
   parent: STClothingHeadHatHoodBase
@@ -442,7 +442,7 @@
   - type: Clothing
     sprite: _Stalker/Objects/Clothing/outerClothing/jacket_sci.rsi
   - type: GrantsArtifactSlots # Stalker EN
-    slots: 2
+    slots: 3
 
 - type: entity
   parent: STClothingHeadHatBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/JacketMods.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T1/JacketMods.yml
@@ -122,7 +122,7 @@
         Radiation: 0.85
         Compression: 0.90
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: Craftable
 
 - type: entity
@@ -175,7 +175,7 @@
         Radiation: 0.85
         Compression: 0.90
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: Craftable
 
 - type: entity

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/Armor6B2.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/Armor6B2.yml
@@ -23,7 +23,7 @@
         Slash: 0.80
         Piercing: 0.75
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: Craftable

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorCN1.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorCN1.yml
@@ -31,7 +31,7 @@
         Psy: 0.8
         Compression: 0.8
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90
   # bonus
@@ -97,7 +97,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCN1
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
 
 - type: entity
   parent: ClothingHeadHelmetZN1

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorInterceptor_OTV.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorInterceptor_OTV.yml
@@ -37,6 +37,6 @@
         Slash: 0.8
         Piercing: 0.8
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorKirasa.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorKirasa.yml
@@ -23,6 +23,6 @@
         Slash: 0.95
         Piercing: 0.95
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorPlateVestLight.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorPlateVestLight.yml
@@ -38,7 +38,7 @@
         Slash: 0.8
         Piercing: 0.8
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: Craftable
@@ -275,7 +275,7 @@
   - type: Contraband # EN
     severity: Monolith
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
 
 
 - type: entity

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorRCBZ.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorRCBZ.yml
@@ -27,7 +27,7 @@
         Caustic: 0.6
         Shock: 0.7
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
@@ -101,7 +101,7 @@
         Caustic: 0.6
         Shock: 0.7
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
 
 - type: entity
   parent: ClothingHelmRCBZ

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorSpark.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorSpark.yml
@@ -30,7 +30,7 @@
             Caustic: 0.8
             Shock: 0.6
     - type: GrantsArtifactSlots
-      slots: 3 # EN
+      slots: 4 # EN
     - type: ClothingSpeedModifier
       walkModifier: 1
       sprintModifier: 1
@@ -91,7 +91,7 @@
         types:
           Radiation: -0.25
     - type: GrantsArtifactSlots
-      slots: 2 # EN
+      slots: 3 # EN
     - type: Storage
       maxItemSize: Large
       grid:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorZarya.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorZarya.yml
@@ -29,7 +29,7 @@
         Caustic: 0.85
         Shock: 0.9
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: Craftable
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ANATactical.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ANATactical.yml
@@ -39,7 +39,7 @@
         Slash: 0.8
         Piercing: 0.7
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: Craftable
@@ -115,7 +115,7 @@
     sprite: _Stalker/Objects/Clothing/outerClothing/ANA/Blue.rsi
   - type: Craftable
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
 
 - type: entity
   parent: STClothingOuterArmorLightPlateVestBaseANAgreen

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorAborigineStalker.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorAborigineStalker.yml
@@ -44,7 +44,7 @@
         Caustic: 0.6
         Shock: 0.8
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.85
   - type: Craftable

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorIOTV.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorIOTV.yml
@@ -33,6 +33,6 @@
         Slash: 0.8
         Piercing: 0.7
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorKorynd.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorKorynd.yml
@@ -23,6 +23,6 @@
         Slash: 0.8
         Piercing: 0.7
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorPSZ7.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorPSZ7.yml
@@ -20,7 +20,7 @@
           Piercing: 0.6
           Heat: 0.9
     - type: GrantsArtifactSlots
-      slots: 2 # EN
+      slots: 3 # EN
     - type: ExplosionResistance
       damageCoefficient: 0.65
     - type: Sprite

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
@@ -39,7 +39,7 @@
         Shock: 0.60
         Compression: 0.7
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
@@ -128,7 +128,7 @@
       clothingPrototype: ClothingHeadHardsuitSevaHelmSci
       slot: head
     - type: GrantsArtifactSlots
-      slots: 4 # EN
+      slots: 5 # EN
 
 - type: entity
   parent: STClothingHeadHardsuitSevaHelmBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSlick.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSlick.yml
@@ -23,7 +23,7 @@
         Slash: 0.9
         Piercing: 0.7
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSuit.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSuit.yml
@@ -45,7 +45,7 @@
         Caustic: 0.80
         Shock: 0.75
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: Craftable
@@ -452,7 +452,7 @@
         Caustic: 0.75
         Shock: 0.85
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorUzk5.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorUzk5.yml
@@ -33,7 +33,7 @@
         Compression: 0.7
         Shock: 0.7
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/cn-4a.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/cn-4a.yml
@@ -41,5 +41,5 @@
         Shock: 0.60
         Compression: 0.7
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/cn-4aResearcher.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/cn-4aResearcher.yml
@@ -41,4 +41,4 @@
         Shock: 0.45
         Compression: 0.6
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/Armor6B13.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/Armor6B13.yml
@@ -19,7 +19,7 @@
         Slash: 0.70
         Piercing: 0.70
   - type: GrantsArtifactSlots
-    slots: 2 # Stalker-Changes | Number of artifact slots this armor grants
+    slots: 3 # Stalker-Changes | Number of artifact slots this armor grants
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: Craftable
@@ -97,7 +97,7 @@
          Shock: 0.85
          Compression: 0.75
     - type: GrantsArtifactSlots
-      slots: 2 # EN
+      slots: 3 # EN
 
 - type: entity
   parent: STClothingOuterArmor6B13Base

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorBerill5M.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorBerill5M.yml
@@ -44,7 +44,7 @@
         Compression: 0.75
         Shock: 0.75
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: Craftable

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorIOTV.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorIOTV.yml
@@ -31,7 +31,7 @@
         Slash: 0.60
         Piercing: 0.60
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: Craftable

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorIOTVGEN4.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorIOTVGEN4.yml
@@ -23,6 +23,6 @@
         Slash: 0.80
         Piercing: 0.55
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.65

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorPSZ9D.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorPSZ9D.yml
@@ -25,7 +25,7 @@
         Piercing: 0.8
         Compression: 0.75
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
 
 - type: entity
   parent: ClothingOuterArmorPSZ9D

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorReinger.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorReinger.yml
@@ -49,7 +49,7 @@
         Psy: 0.80
         Compression: 0.50
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetReinger
     slot: head

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorSSP99.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorSSP99.yml
@@ -43,7 +43,7 @@
         Radiation: 0.60
         Compression: 0.60
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorSuitHeavy.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorSuitHeavy.yml
@@ -46,7 +46,7 @@
         Psy: 1
         Compression: 0.75
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: ToggleableClothing
@@ -87,7 +87,7 @@
         Shock: 0.75
         Compression: 0.75
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
 
 - type: entity
   parent: STClothingOuterArmorVeryHeavy

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorYeger.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/ArmorYeger.yml
@@ -33,7 +33,7 @@
         Psy: 0.25
         Compression: 0.25
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/MakeshiftOuterArmor.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T4/MakeshiftOuterArmor.yml
@@ -28,7 +28,7 @@
         Shock: 0.85
         Compression: 0.85
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: Craftable

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorBulat.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorBulat.yml
@@ -28,7 +28,7 @@
         Compression: 0.7
         Shock: 0.75
   - type: GrantsArtifactSlots
-    slots: 3 # EN
+    slots: 4 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.6
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorEliteRanger.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorEliteRanger.yml
@@ -28,6 +28,6 @@
         Psy: 0.50
         Compression: 0.50
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.2

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorExoskeleton.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorExoskeleton.yml
@@ -27,7 +27,7 @@
         Heat: 0.35
         Radiation: 0.65
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.25
   - type: PressureProtection

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorHazmat.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorHazmat.yml
@@ -32,7 +32,7 @@
           Shock: 0.5
           Compression: 0.5
     - type: GrantsArtifactSlots
-      slots: 3 # EN
+      slots: 4 # EN
 
 - type: entity
   parent: STClothingHeadHatBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorPlateVestHeavy.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorPlateVestHeavy.yml
@@ -21,7 +21,7 @@
         Slash: 0.7
         Piercing: 0.6
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: Sprite

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorRatnik.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorRatnik.yml
@@ -22,7 +22,7 @@
         Blunt: 0.6
         Slash: 0.6
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.5
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorRedut.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T5/ArmorRedut.yml
@@ -21,7 +21,7 @@
         Slash: 0.65
         Piercing: 0.9
   - type: GrantsArtifactSlots
-    slots: 1 # EN
+    slots: 2 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
Increased the number of artifact slots all armor can hold by 1 across the board, except when it was set to 0. 

I personally feel like the current system restricts interesting artifact combinations or experimentation quite heavily. And the fact that basically only the SSP's get 5 slots means that globally we have basically gotten a slot taken away, unless you happen to be eco (and imo the SSP's are plenty powerful due to stats and space alone). 

This change alleviates the problem a teeny bit.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Wintoli

- tweak: Globally increased the number of artifact slots on armor by 1.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
