### PR TITLE
Increase max contacts from 50 to 255

### DIFF
--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class STMessengerSystem : EntitySystem
 
     private const int MaxChannelMessages = 200;
     private const int MaxDmMessages = 100;
-    private const int MaxContacts = 50;
+    private const int MaxContacts = 100;
     private const int MaxRetryCollision = 10;
     private const int MaxPseudonymSuffix = 999;
     private static readonly TimeSpan InteractionCooldown = TimeSpan.FromSeconds(0.5);

--- a/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
+++ b/Content.Server/_Stalker_EN/PdaMessenger/STMessengerSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class STMessengerSystem : EntitySystem
 
     private const int MaxChannelMessages = 200;
     private const int MaxDmMessages = 100;
-    private const int MaxContacts = 100;
+    private const int MaxContacts = 255;
     private const int MaxRetryCollision = 10;
     private const int MaxPseudonymSuffix = 999;
     private static readonly TimeSpan InteractionCooldown = TimeSpan.FromSeconds(0.5);


### PR DESCRIPTION
Ive genuinely been having issues with that bottleneck and i dont want to move my contacts into a fucking excel file so i can receive more DMs

<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->

increased the number of available contacts (and by extension DM channels) you can have from 50 to 255.

Genuinely no reason as to why we should limit the contacts to such a small amount, if people want to stay under 50 they can just manually delete contacts.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Cassandra

- tweak: PDA messenger can now store more contacts

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
