### PR TITLE
Changing Clear Sky Armours.

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorCN1.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T2/ArmorCN1.yml
@@ -17,21 +17,21 @@
     armorClass: 2
     modifiers:
       flatReductions:
-        Blunt: 3
-        Slash: 3
-        Piercing: 6
-        Radiation: 1.5
+        Blunt: 4
+        Slash: 7
+        Piercing: 2
+        Radiation: 1
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.5
-        Heat: 0.65
-        Caustic: 0.95
-        Shock: 0.65
-        Psy: 0.8
-        Compression: 0.8
+        Blunt: 0.7
+        Slash: 0.65
+        Compression: 0.80
+        Piercing: 0.8
+        Heat: 0.80
+        Caustic: 0.9
+        Shock: 0.80
+
   - type: GrantsArtifactSlots
-    slots: 2 # EN
+    slots: 3 # EN
   - type: ExplosionResistance
     damageCoefficient: 0.90
   # bonus

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSuit.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSuit.yml
@@ -505,21 +505,16 @@
     modifiers:
       flatReductions:
         Blunt: 3
-        Slash: 4
-        Piercing: 4
-        Radiation: 2
-        Heat: 1
-        Caustic: 1
-        Shock: 1
+        Slash: 3
+        Piercing: 6
+        Radiation: 1
       coefficients:
-        Blunt: 0.60
-        Slash: 0.55
-        Piercing: 0.85
-        Compression: 0.7
-        Radiation: 0.75
-        Heat: 0.75
-        Caustic: 0.70
-        Shock: 0.75
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.50
+        Heat: 0.90
+        Caustic: 0.95
+        Shock: 0.90
 
 - type: entity
   parent: STClothingOuterArmorBase

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
@@ -302,7 +302,7 @@
       ClothingOuterArmorRCBZCN: 1450 # T2 - ENV
       ClothingOuterArmorCN1: 2100 # T2 - PVE
       STClothingOuterArmorLightPlateVestBaseANABlue: 9500 # T3 - PVP
-      ClothingOuterArmorCN3a: 19000 # T3 - PVP
+      ClothingOuterArmorCN3a: 22000 # T3 - PVP
       ClothingOuterArmorSevaCN: 3600 # T3 - ENVl
       STClothingOuterArmorCN-4a: 3600 # Illusion of choice
       STClothingOuterArmorCN-4aResearcher: 4000 # Slightly better SEVA

--- a/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
+++ b/Resources/Prototypes/_Stalker_EN/ShopPresets/FactionTorgomats/clearsky.yml
@@ -300,13 +300,13 @@
       STClothingOuterArmorLightPlateVestBaseClearSky: 1100 # T2 - PvP
       ClothingOuterArmor6B2: 1450 # T2 - PvP
       ClothingOuterArmorRCBZCN: 1450 # T2 - ENV
-      ClothingOuterArmorCN1: 2100 # T2 - universal
+      ClothingOuterArmorCN1: 2100 # T2 - PVE
       STClothingOuterArmorLightPlateVestBaseANABlue: 9500 # T3 - PVP
-      ClothingOuterArmorCN3a: 12000 # T3 - PVE
+      ClothingOuterArmorCN3a: 19000 # T3 - PVP
       ClothingOuterArmorSevaCN: 3600 # T3 - ENVl
       STClothingOuterArmorCN-4a: 3600 # Illusion of choice
       STClothingOuterArmorCN-4aResearcher: 4000 # Slightly better SEVA
-      ClothingOuterArmorSevaClearSky: 15000 # T3 - ENV/PVP
+      ClothingOuterArmorSevaClearSky: 14500 # T3 - ENV/PVP
 
   - name: shop-category-storage-and-containers
     priority: 7


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Changed Clear sky's armor to make more sense, altered shop prices to be more true to their value.
## Changelog

author: @simpleleaf0
 - tweak: Changed the CN-1 from being a 50% pierce cheap PvP armor to being a Cynocologst sunrise equivalent.
 - tweak: Changed the CN3a from being a PvE armor to having the PvP stats of the current CN-1, with the PvE stats of the highest equivalent PvP armor the PSZ-7
 - tweak: Raised CN3a price to 22k from 12k to make it justified for being the best in the game.
 - tweak: Lowered Troposphere hazmat suit's price from 15k to 14.5k to encourage usage

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X]  I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
