### PR TITLE
Give all SEVA suits the same 4 artifact slots

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
@@ -39,7 +39,7 @@
         Shock: 0.60
         Compression: 0.7
   - type: GrantsArtifactSlots
-    slots: 4 # EN
+    slots: 5 # EN
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
@@ -111,8 +111,6 @@
       sprite: _Stalker/Objects/Clothing/outerClothing/seva_red.rsi
     - type: Clothing
       sprite: _Stalker/Objects/Clothing/outerClothing/seva_red.rsi
-    - type: GrantsArtifactSlots
-      slots: 5 # EN
 
 - type: entity
   parent: STClothingOuterArmorSevaBase
@@ -254,8 +252,6 @@
     sprite: _Stalker/Objects/Clothing/outerClothing/seva_cn.rsi
   - type: Clothing
     sprite: _Stalker/Objects/Clothing/outerClothing/seva_cn.rsi
-  - type: GrantsArtifactSlots
-    slots: 5 # EN
 
 # Merc
 

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
@@ -39,7 +39,7 @@
         Shock: 0.60
         Compression: 0.7
   - type: GrantsArtifactSlots
-    slots: 5 # EN
+    slots: 4
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
@@ -125,8 +125,6 @@
     - type: ToggleableClothing
       clothingPrototype: ClothingHeadHardsuitSevaHelmSci
       slot: head
-    - type: GrantsArtifactSlots
-      slots: 4 # EN
 
 - type: entity
   parent: STClothingHeadHardsuitSevaHelmBase

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Clothing/OuterClothing/T3/ArmorSeva.yml
@@ -39,7 +39,7 @@
         Shock: 0.60
         Compression: 0.7
   - type: GrantsArtifactSlots
-    slots: 4
+    slots: 4 # EN
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Ever since limited artifact slots were added, the Eco SEVA has been the best by far. A extra slot (5 instead of 4), on top of it's remarkably low price severely disadvantages anyone who wants to represent their own faction, or just look cool.
I've bumped the other SEVA suits up to 5 slots as standard, though this could also be fixed by dropping the Eco SEVA to 4 slots.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Nox38 

- tweak: All SEVAs now get 5 artifact slots, instead of just Eco SEVAs.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
