### PR TITLE
The G-36 Can Have a Silencer Now

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/g36.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/g36.yml
@@ -37,6 +37,12 @@
         whitelist:
           tags:
           - Magazine556
+      gun_module_muzzle:
+        name: Muzzle
+        priority: 3
+        whitelist:
+          tags:
+          - STWeaponModuleRifleSilencerNato
       gun_chamber:
         name: Chamber
         startingItem:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/g36.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/g36.yml
@@ -37,12 +37,12 @@
         whitelist:
           tags:
           - Magazine556
-      gun_module_muzzle:
+      gun_module_muzzle: #EN Start
         name: Muzzle
         priority: 3
         whitelist:
           tags:
-          - STWeaponModuleRifleSilencerNato
+          - STWeaponModuleRifleSilencerNato #EN End
       gun_chamber:
         name: Chamber
         startingItem:


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
The G-36 can have a silencer attached now. I could not find any realism reason or gameplay reason why it shouldn't be allowed to have one compared to all other rifles.

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Wintoli

- tweak: The G-36 can now equip a silencer.

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [x] Yes, I ran my code and tested that the changes worked
- [x] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [x] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [x] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
