### PR TITLE
Armor Tiers

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -40,39 +40,6 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             || component.ProjectileSpent || component is { Weapon: null, OnlyCollideWhenShot: true })
             return;
 
-        // stalker-changes-start
-        var ignoreResitance = false;
-        List<EntityUid> ignore = new();
-        string[] slots = {
-            "outerClothing",
-            "head",
-            "cloak",
-            "eyes",
-            "ears",
-            "mask",
-            "jumpsuit",
-            "neck",
-            "back",
-            "belt",
-            "gloves",
-            "shoes",
-            "id",
-            "legs",
-            "torso"
-        };
-
-        foreach (var slot in slots)
-        {
-            if (_inventory.TryGetSlotEntity(args.OtherEntity, slot, out var entity) && TryComp<ArmorComponent>(entity, out var armorComp) && armorComp.ArmorClass.HasValue)
-                if (component.ProjectileClass >= armorComp.ArmorClass.Value)
-                    ignore.Add(entity.Value);
-        }
-
-        if (TryComp<DamageableComponent>(args.OtherEntity, out var damageable) && damageable.DamageModifierSetId != null)
-            if (_prototype.TryIndex(damageable.DamageModifierSetId, out var damageModifierSetPrototype))
-                ignoreResitance = component.ProjectileClass >= damageModifierSetPrototype.Class;
-        // stalker-changes-end
-
         var target = args.OtherEntity;
         // it's here so this check is only done once before possible hit
         var attemptEv = new ProjectileReflectAttemptEvent(uid, component, false);
@@ -95,7 +62,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
         var deleted = Deleted(target);
 
-        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances || ignoreResitance, origin: component.Shooter, ignoreResistors: ignore) && Exists(component.Shooter)) // Stalker-Changes-IgnoreResistors
+        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, damageTier: component.ProjectileClass) && Exists(component.Shooter)) // stalker-en-changes : damageTier
         {
             if (!deleted)
             {

--- a/Content.Server/_Stalker/Psyonics/Actions/Shield/PsyonicsShieldSystem.cs
+++ b/Content.Server/_Stalker/Psyonics/Actions/Shield/PsyonicsShieldSystem.cs
@@ -39,9 +39,6 @@ public sealed class PsyonicsShieldSystem : BasePsyonicsActionSystem<PsyonicsActi
     }
     private void OnDamageModified(EntityUid uid, PsyonicsActionShieldComponent component, DamageModifyEvent args)
     {
-        if (args.IgnoreResistors.Contains(uid))
-            return;
-
         if (!component.IsActive)
             return;
         var initialHealth = component.Health;

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -70,20 +70,73 @@ public abstract partial class SharedArmorSystem : EntitySystem
             return;
 
         // stalker-changes-start
-        if (args.Args.IgnoreResistors.Contains(uid))
+        if (component.ArmorClass < args.Args.DamageTier)
         {
             if (component.Modifiers == null)
                 return;
 
+            var armorTier = component.ArmorClass;
+            var damageTier = args.Args.DamageTier;
+            var diff = damageTier - armorTier;
+
             var modifiedModifiers = new DamageModifierSet
             {
                 Coefficients = new Dictionary<string, float>(component.Modifiers.Coefficients),
-                FlatReduction = new Dictionary<string, float>(component.Modifiers.FlatReduction)
+                FlatReduction = new Dictionary<string, float>(component.Modifiers.FlatReduction),
             };
 
+
+            // Each tier below the projectile will remove 20% of the armor coefficient effectiveness, additively
+            // 25% becomes 15% with a 2 tier difference, et cetera
             foreach (var key in modifiedModifiers.Coefficients.Keys.ToList())
             {
-                modifiedModifiers.Coefficients[key] = 1f;
+                var reducedCoefficient = (1f - modifiedModifiers.Coefficients[key]) / 5f;
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.Coefficients[key] += reducedCoefficient;
+                    if (modifiedModifiers.Coefficients[key] >= 1f)
+                        modifiedModifiers.Coefficients[key] = 1f;
+                }
+            }
+
+            // It also reduces flat reduction by 1 per tier difference
+            foreach (var key in modifiedModifiers.FlatReduction.Keys.ToList())
+            {
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.FlatReduction[key] -= 1;
+                    if (modifiedModifiers.FlatReduction[key] <= 0)
+                        modifiedModifiers.FlatReduction[key] = 0;
+                }
+            }
+
+            args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, modifiedModifiers);
+
+            return;
+        }
+
+        if (component.ArmorClass > args.Args.DamageTier)
+        {
+            if (component.Modifiers == null)
+                return;
+
+            var armorTier = component.ArmorClass;
+            var damageTier = args.Args.DamageTier;
+            var diff = armorTier - damageTier;
+
+            var modifiedModifiers = new DamageModifierSet
+            {
+                Coefficients = new Dictionary<string, float>(component.Modifiers.Coefficients),
+                FlatReduction = component.Modifiers.FlatReduction,
+            };
+
+            // Each tier stronger the armor is to the projectile makes it 40% more effective
+            foreach (var key in modifiedModifiers.Coefficients.Keys.ToList())
+            {
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.Coefficients[key] *= 0.6f;
+                }
             }
 
             args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, modifiedModifiers);
@@ -109,20 +162,68 @@ public abstract partial class SharedArmorSystem : EntitySystem
             return;
 
         // stalker-changes-start
-        if (args.Args.IgnoreResistors.Contains(uid))
+        if (component.ArmorClass < args.Args.DamageTier)
         {
             if (component.Modifiers == null)
                 return;
 
+            var armorTier = component.ArmorClass;
+            var damageTier = args.Args.DamageTier;
+            var diff = damageTier - armorTier;
+
             var modifiedModifiers = new DamageModifierSet
             {
                 Coefficients = new Dictionary<string, float>(component.Modifiers.Coefficients),
-                FlatReduction = component.Modifiers.FlatReduction
+                FlatReduction = new Dictionary<string, float>(component.Modifiers.FlatReduction),
             };
 
             foreach (var key in modifiedModifiers.Coefficients.Keys.ToList())
             {
-                modifiedModifiers.Coefficients[key] = 1f;
+                var reducedCoefficient = (1f - modifiedModifiers.Coefficients[key]) / 5f;
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.Coefficients[key] += reducedCoefficient;
+                    if (modifiedModifiers.Coefficients[key] >= 1f)
+                        modifiedModifiers.Coefficients[key] = 1f;
+                }
+            }
+
+            foreach (var key in modifiedModifiers.FlatReduction.Keys.ToList())
+            {
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.FlatReduction[key] -= 1;
+                    if (modifiedModifiers.FlatReduction[key] <= 0)
+                        modifiedModifiers.FlatReduction[key] = 0;
+                }
+            }
+
+            args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, modifiedModifiers);
+
+            return;
+        }
+
+        if (component.ArmorClass > args.Args.DamageTier)
+        {
+            if (component.Modifiers == null)
+                return;
+
+            var armorTier = component.ArmorClass;
+            var damageTier = args.Args.DamageTier;
+            var diff = armorTier - damageTier;
+
+            var modifiedModifiers = new DamageModifierSet
+            {
+                Coefficients = new Dictionary<string, float>(component.Modifiers.Coefficients),
+                FlatReduction = component.Modifiers.FlatReduction,
+            };
+
+            foreach (var key in modifiedModifiers.Coefficients.Keys.ToList())
+            {
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.Coefficients[key] *= 0.6f;
+                }
             }
 
             args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, modifiedModifiers);

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -127,15 +127,26 @@ public abstract partial class SharedArmorSystem : EntitySystem
             var modifiedModifiers = new DamageModifierSet
             {
                 Coefficients = new Dictionary<string, float>(component.Modifiers.Coefficients),
-                FlatReduction = component.Modifiers.FlatReduction,
+                FlatReduction = new Dictionary<string, float>(component.Modifiers.FlatReduction),
             };
 
-            // Each tier stronger the armor is to the projectile makes it 40% more effective
+            // Each tier stronger the armor is to the projectile adds 50% of its own protection on top
             foreach (var key in modifiedModifiers.Coefficients.Keys.ToList())
+            {
+                var addedCoefficient =
+                    modifiedModifiers.Coefficients[key] + (1 - modifiedModifiers.Coefficients[key]) / 2;
+                for (var i = 0; i < diff; i++)
+                {
+                    modifiedModifiers.Coefficients[key] *= addedCoefficient;
+                }
+            }
+
+            // 1 flat per too
+            foreach (var key in modifiedModifiers.FlatReduction.Keys.ToList())
             {
                 for (var i = 0; i < diff; i++)
                 {
-                    modifiedModifiers.Coefficients[key] *= 0.6f;
+                    modifiedModifiers.FlatReduction[key] += 1;
                 }
             }
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.API.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.API.cs
@@ -96,12 +96,12 @@ public sealed partial class DamageableSystem
         bool interruptsDoAfters = true,
         EntityUid? origin = null,
         bool ignoreGlobalModifiers = false,
-        List<EntityUid>? ignoreResistors = null // Stalker-Changes : ignoreResistors
+        int? damageTier = null // stalker-en-changes : damageTier
     )
     {
         //! Empty just checks if the DamageSpecifier is _literally_ empty, as in, is internal dictionary of damage types is empty.
         // If you deal 0.0 of some damage type, Empty will be false!
-        newDamage = ChangeDamage(ent, damage, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers, ignoreResistors); // Stalker-Changes : ignoreResistors
+        newDamage = ChangeDamage(ent, damage, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers, damageTier); // stalker-en-changes : damageTier
         return !damage.Empty;
     }
 
@@ -123,7 +123,7 @@ public sealed partial class DamageableSystem
         bool interruptsDoAfters = true,
         EntityUid? origin = null,
         bool ignoreGlobalModifiers = false,
-        List<EntityUid>? ignoreResistors = null // Stalker-Changes : ignoreResistors
+        int? damageTier = null // stalker-en-changes : damageTier
     )
     {
         var damageDone = new DamageSpecifier();
@@ -151,7 +151,7 @@ public sealed partial class DamageableSystem
 
             // TODO DAMAGE
             // byref struct event.
-            var ev = new DamageModifyEvent(damage, origin, ignoreResistors); // Stalker-Changes : ignoreResistors
+            var ev = new DamageModifyEvent(damage, origin, damageTier); // stalker-en-changes : damageTier
             RaiseLocalEvent(ent, ev);
             damage = ev.Damage;
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -216,7 +216,7 @@ public record struct BeforeDamageChangedEvent(DamageSpecifier Damage, EntityUid?
 ///
 ///     For example, armor.
 /// </summary>
-public sealed class DamageModifyEvent(DamageSpecifier damage, EntityUid? origin = null, List<EntityUid>? ignoreResistors = null)
+public sealed class DamageModifyEvent(DamageSpecifier damage, EntityUid? origin = null, int? damageTier = null) // stalker-en-changes : damageTier
     : EntityEventArgs, IInventoryRelayEvent
 {
     // Whenever locational damage is a thing, this should just check only that bit of armour.
@@ -224,7 +224,7 @@ public sealed class DamageModifyEvent(DamageSpecifier damage, EntityUid? origin 
 
     public readonly DamageSpecifier OriginalDamage = damage;
     public DamageSpecifier Damage = damage;
-    public List<EntityUid> IgnoreResistors = ignoreResistors ?? new List<EntityUid>();  // stalker-changes
+    public int? DamageTier = damageTier; // stalker-en-changes : damageTier
 }
 
 public sealed class DamageChangedEvent : EntityEventArgs

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -99,14 +99,15 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             ? _damageableSystem.ChangeDamage(target,
                 ev.Damage,
                 component.IgnoreResistances,
-                origin: component.Shooter)
+                origin: component.Shooter,
+                damageTier: projectile.Comp1.ProjectileClass) // stalker-en-changes : damageTier
             : new DamageSpecifier(ev.Damage);
         var deleted = Deleted(target);
 
         // RMC14 this is already done on the server in TryChangeDamage.
         if (_net.IsClient)
         {
-            var modifyEvent = new DamageModifyEvent(ev.Damage, component.Shooter, new List<EntityUid> { uid });
+            var modifyEvent = new DamageModifyEvent(ev.Damage, component.Shooter, projectile.Comp1.ProjectileClass);
             RaiseLocalEvent(target, modifyEvent);
             modifiedDamage = modifyEvent.Damage;
         }


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

This isn't ragebait

## What I changed
Adding armor tiers, I'll get a little more technical in the second half, but going to start by talking about the implementation itself

Armor tiers now provide either more or less protection against projectiles, depending on their tiers. Each armor tier above the fired ammo will add 50% of its own protection on top, multiplicatively. It also adds 1 flat reduction. Let's use the M80 round as an example. It's a tier 3 round, doing 35 pierce, reduced to 28 by the Beryl's 7 flat reduction. 28x0.75=21. But because the Beryl is tier 4, it would be reduced to 27 instead. 27x0.75x0.875=17.71875. If the Beryl was Tier 5, it would be reduced to 26, then 26x0.75x0.875x0.875=14.9296875. If the Beryl had a higher pierce protection, this would become even more apparent.

And the other way around. Each tier of armor below the fired projectile will protect you 20% less. That's 20% less, additively, of the **ARMOR**, not _TOTAL_. Meaning that 25% would become 20%, then 15%, all the way down to 0% at a 5 tier difference. It will also remove 1 flat reduction per tier, also down to 0.

If the armor and ammo match in tiers, the displayed protective values on the armor hold true. This applies per armor piece, meaning that tier 4 body armor will make that armor piece 50% more protective against tier 3 ammo, but your tier 3 coat and helmet won't benefit from it.

This also fixes the "random crits" where ammo matching or exceeding an armor tier will randomly decide to completely ignore the armor, leading to 3-4 taps.



More technical side of things. I had to change DamageModifyEvent to remove and replace IgnoreResistors since it was redundant, and also existed for armor tiers. Instead of making the check in ProjectileSystem and then saving the armor uid to a list, the event now carries the projectile class as an int, in DamageTier, so that the logic can be ran in SharedArmorSystem. Additionally, ProjectileSystem/OnStartCollide & SharedProjectileSystem/ProjectileCollide fight over priority, and since only one can run, I had to update ProjectileCollide to stop the "random crits". 

Also, armor that has no assigned armor class and is null (will still display armor class 0 on inspect) aren't affected by this either, and act like they match the ammo tier

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Llfiend

- add: Armor Tiers

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
