### PR TITLE
feat: add ambush AI that stays still until a player nears or it's hurt

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Mobs/Mutants/T3/mannequin.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Mobs/Mutants/T3/mannequin.yml
@@ -82,12 +82,12 @@
     needsHands: false
   - type: HTN
     rootTask:
-      task: STSimpleHostileCompound
+      task: STAmbushHostileCompound # stand still until a player comes within VisionRadius (or it's damaged), then hunt like a normal mutant
     blackboard:
       VisionRadius: !type:Single
-        20
+        3 # proximity trigger: won't notice players past 3 tiles
       AggroVisionRadius: !type:Single
-        3
+        20 # once provoked, keeps hunting out to 20 tiles before re-freezing
   - type: MeleeThrowOnHit # Could add some oomph to it, less than bears
     speed: 3
     distance: 0.5

--- a/Resources/Prototypes/_Stalker_EN/HTNs/Combat/ambush.yml
+++ b/Resources/Prototypes/_Stalker_EN/HTNs/Combat/ambush.yml
@@ -1,0 +1,49 @@
+# "Ambush" mob AI: behaves like STSimpleHostileCompound, but stands perfectly still
+# instead of wandering when it has no target. Pair it with a small VisionRadius (e.g. 3)
+# so the mob only "notices" players who get close, and a larger AggroVisionRadius so it
+# keeps hunting once provoked. When it loses its target it falls back to standing still.
+
+# Stand perfectly still (no movement) and wait. Used as the idle fallback so the mob keeps
+# its static, non-moving sprite until a higher-priority (combat) branch becomes valid.
+- type: htnCompound
+  id: STStandStillCompound
+  branches:
+    - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:WaitOperator
+            key: IdleTime
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: IdleTime
+
+    - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:RandomOperator
+            targetKey: IdleTime
+            minKey: MinimumIdleTime
+            maxKey: MaximumIdleTime
+        - !type:HTNPrimitiveTask
+          operator: !type:WaitOperator
+            key: IdleTime
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: IdleTime
+
+- type: htnCompound
+  id: STAmbushHostileCompound
+  branches:
+    - tasks: # break free if a player grabs/pulls it
+        - !type:HTNPrimitiveTask
+          operator: !type:UnPullOperator
+          preconditions:
+            - !type:PulledPrecondition
+              isPulled: true
+    - tasks: # chase and melee a living target within vision
+        - !type:HTNCompoundTask
+          task: STSimpleMeleeCombatAliveCompound
+    - tasks: # finish off a downed/crit target
+        - !type:HTNCompoundTask
+          task: STSimpleMeleeCombatCritCompound
+    - tasks: # no target in range: stand still (the "ambush" state)
+        - !type:HTNCompoundTask
+          task: STStandStillCompound


### PR DESCRIPTION
## What I changed

New data-only HTN behaviour `STAmbushHostileCompound` (in `_Stalker_EN/HTNs/Combat/ambush.yml`): the mob stays completely still until a player comes within 3 tiles or it takes damage, then drops into the standard mutant melee AI and re-freezes once it loses the target. Wired it onto the Mannequin and tuned its vision (VisionRadius 3, AggroVisionRadius 20). 

## Changelog
author: @teecoding

- add: Mannequins now stay frozen until you get close or hit them, then spring to life and chase.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license