### PR TITLE
Add empty jugs for liquid storage

### DIFF
--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Consumable/Drinks/drink_bottle.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Consumable/Drinks/drink_bottle.yml
@@ -328,3 +328,21 @@
     keepFirst: true
     exactFirst: false
     time: 3
+
+- type: entity
+  parent: [DrinkVisualsOpenable, DrinkBottlePlasticBaseFull]
+  id: GenericJug
+  name: Jug
+  description: A nondescript plastic jug to store liquids
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 400
+        # reagents:
+        # - ReagentId: GreenTea
+        #   Quantity: 300
+  # - type: Label
+  #   currentLabel: reagent-name-green-tea
+  - type: Sprite
+    sprite: Objects/Consumable/Drinks/generic_jug.rsi

--- a/Resources/Prototypes/_Stalker_EN/Entities/Objects/Consumable/Drinks/drink_bottle.yml
+++ b/Resources/Prototypes/_Stalker_EN/Entities/Objects/Consumable/Drinks/drink_bottle.yml
@@ -332,6 +332,7 @@
 - type: entity
   parent: [DrinkVisualsOpenable, DrinkBottlePlasticBaseFull]
   id: GenericJug
+  suffix: Empty
   name: Jug
   description: A nondescript plastic jug to store liquids
   components:
@@ -339,10 +340,14 @@
     solutions:
       drink:
         maxVol: 400
-        # reagents:
-        # - ReagentId: GreenTea
-        #   Quantity: 300
-  # - type: Label
-  #   currentLabel: reagent-name-green-tea
   - type: Sprite
     sprite: Objects/Consumable/Drinks/generic_jug.rsi
+
+- type: entity
+  parent: GenericJug
+  id: ArmoredJug
+  name: Armored Jug
+  description: A armored plastic jug to safely store liquids
+  components:
+  - type: ExplosionResistance
+    damageCoefficient: 0.0


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->
Added a generic jug and an armored version of it to allow it to be added to stores.

Point is to be able to properly store liquids without having to put them in a reused green tea jug.

Armored jug does not spill its contents when blown up.
## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @cris5311

- add: Generic Jugs

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
