### PR TITLE
762x51 adjustments (SCAR-H & Galatz)

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/Galatz.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/Galatz.yml
@@ -12,7 +12,7 @@
   - type: Clothing
     sprite: _Stalker/Objects/Weapons/Guns/Rifles/galatz.rsi
   - type: Gun
-    fireRate: 5
+    fireRate: 3.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -20,10 +20,11 @@
       path: /Audio/_Stalker/Effects/Guns/sks_shoot.ogg
       params:
         volume: -2
-    minAngle: 44
-    maxAngle: 120
-    angleIncrease: 5
-    angleDecay: 25
+    minAngle: 55
+    maxAngle: 110
+    angleIncrease: 1
+    angleDecay: 7.5
+    projectileSpeed: 75
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -46,7 +47,7 @@
         priority: 2
         whitelist:
           tags:
-          - STWeaponModuleRifleScopeNato
+          - STWeaponModuleSniperSight
       gun_chamber:
         name: Chamber
         startingItem:
@@ -55,9 +56,9 @@
           tags:
           - STCartridge751
   - type: STWeaponDamageFalloff
-    falloffMultiplier: 0
+    falloffMultiplier: 0.7
   - type: STWeaponAccuracy
-    accuracyMultiplier: 5
+    accuracyMultiplier: 3
 
 - type: entity
   parent: STBaseWeaponRifleGalatz

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/scar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/scar.yml
@@ -13,18 +13,18 @@
   - type: Clothing
     sprite: _Stalker/Objects/Weapons/Guns/Rifles/scar.rsi
   - type: Gun
-    fireRate: 6.5
+    fireRate: 6.2 # EN changes, 6.5 -> 6.2
     soundGunshot:
       path: /Audio/_Stalker/Effects/Guns/scar.ogg
     minAngle: 50
-    maxAngle: 110
-    angleIncrease: 1.2
+    maxAngle: 100
+    angleIncrease: 1.3 # EN changes, 1.2 -> 1.3
     selectedMode: FullAuto
     availableModes:
     - Burst
     - SemiAuto
     - FullAuto
-    angleDecay: 9.5
+    angleDecay: 8.5 # EN changes, 9.5 -> 8.5
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/scar.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Rifles/scar.yml
@@ -17,7 +17,7 @@
     soundGunshot:
       path: /Audio/_Stalker/Effects/Guns/scar.ogg
     minAngle: 50
-    maxAngle: 100
+    maxAngle: 100 # EN changes, 110 -> 100
     angleIncrease: 1.3 # EN changes, 1.2 -> 1.3
     selectedMode: FullAuto
     availableModes:


### PR DESCRIPTION
<!-- If you have any questions, please contact our discord https://discord.gg/SnUSV76zR3 -->

## What I changed
<!-- Write what you changed or add pictures -->

SCAR-H gets a little accuracy hit and fire rate down to 6.2
It's not gutted, just not SSS tier anymore

Galatz now takes sniper sights, the accuracy is increased, fire rate is down to 3.5
Yes it has falloff

## Changelog
<!--
Optional: Describe player-facing changes for the in-game changelog.
If no changelog entry is needed, delete EVERYTHING from "## Changelog" to the end of this section.

IMPORTANT: Keep the "## Changelog" header exactly as-is - the automation requires it.

Available types:
  - add: New feature or content
  - remove: Removed feature or content
  - tweak: Adjustment or enhancement to existing feature
  - fix: Bug fix

Fill in your username and replace the example entry below.
Multiple entries allowed (one per line), but each entry must be unique.
-->
author: @Llfiend

- tweak: SCAR-H nerf
- tweak: Galatz adjustment

<!-- Put X — [X]: -->
## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
