### PR TITLE
General Eco Compound Fixes

### DIFF
--- a/Resources/Maps/_ST/World/Agroprom.yml
+++ b/Resources/Maps/_ST/World/Agroprom.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/26/2026 18:11:45
-  entityCount: 16284
+  time: 06/27/2026 10:43:06
+  entityCount: 16361
 maps:
 - 1
 grids:
@@ -3163,6 +3163,13 @@ entities:
             33564: -193,-91
             33565: -192,-93
             33566: -188,-92
+        - node:
+            color: '#FFFFFFFF'
+            id: FlowersBROne
+          decals:
+            33732: -173.71991,-87.985725
+            33733: -175.04803,-88.017
+            33734: -177.02933,-87.985725
         - node:
             color: '#FFFFFFFF'
             id: GrayConcreteTrimCornerNe
@@ -33419,6 +33426,14 @@ entities:
     - type: Transform
       pos: 16.5,-122.5
       parent: 1
+- proto: AlwaysPoweredLightLED
+  entities:
+  - uid: 10761
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -206.5,-156.5
+      parent: 1
 - proto: AlwaysPoweredlightRed
   entities:
   - uid: 5
@@ -40113,17 +40128,12 @@ entities:
       parent: 1
     - type: ElectronicsSearchable
       timeBeforeNextSearch: -5382.2866
-  - uid: 1268
+  - uid: 1279
     components:
-    - type: MetaData
-      desc: Устройство или инструмент, используемый в научных целях, включая изучение как природных явлений, так и теоретических исследований.
-      name: Научный прибор
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -200.5,-141.5
+      pos: -200.5,-143.5
       parent: 1
-    - type: ElectronicsSearchable
-      timeBeforeNextSearch: -5382.2866
 - proto: BrokenMachineS10
   entities:
   - uid: 1269
@@ -40144,6 +40154,12 @@ entities:
     components:
     - type: Transform
       pos: -168.5,-64.5
+      parent: 1
+  - uid: 1268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -200.5,-141.5
       parent: 1
   - uid: 1270
     components:
@@ -40175,19 +40191,14 @@ entities:
       parent: 1
     - type: ElectronicsSearchable
       timeBeforeNextSearch: -5382.2866
-  - uid: 1274
-    components:
-    - type: MetaData
-      desc: Устройство или инструмент, используемый в научных целях, включая изучение как природных явлений, так и теоретических исследований.
-      name: Научный прибор
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -200.5,-143.5
-      parent: 1
-    - type: ElectronicsSearchable
-      timeBeforeNextSearch: -5382.2866
 - proto: BrokenMachineS3
   entities:
+  - uid: 1274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -200.5,-142.5
+      parent: 1
   - uid: 1275
     components:
     - type: Transform
@@ -40213,17 +40224,6 @@ entities:
     components:
     - type: Transform
       pos: -126.5,-16.5
-      parent: 1
-    - type: ElectronicsSearchable
-      timeBeforeNextSearch: -5382.2866
-  - uid: 1279
-    components:
-    - type: MetaData
-      desc: Устройство или инструмент, используемый в научных целях, включая изучение как природных явлений, так и теоретических исследований.
-      name: Научный прибор
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -200.5,-142.5
       parent: 1
     - type: ElectronicsSearchable
       timeBeforeNextSearch: -5382.2866
@@ -44632,6 +44632,8 @@ entities:
     - type: Transform
       pos: -192.5,-141.5
       parent: 1
+    missingComponents:
+    - ApcPowerReceiver
 - proto: ChessBoard
   entities:
   - uid: 2142
@@ -44647,11 +44649,36 @@ entities:
   - uid: 2144
     components:
     - type: MetaData
-      desc: В нём что то бурлит.
-      name: Научный прибор
+      desc: You could swear there is something floating in there.
+      name: Specimen Holding Cell
     - type: Transform
       pos: -198.5,-145.5
       parent: 1
+- proto: ClothingBandageStalkerPurple
+  entities:
+  - uid: 10753
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -204.5109,-122.12166
+      parent: 1
+    missingComponents:
+    - Item
+    - Physics
+    - Fixtures
+    - Pullable
+- proto: ClothingHeadHatSurgcapBlue
+  entities:
+  - uid: 10760
+    components:
+    - type: Transform
+      pos: -207.65025,-155.32138
+      parent: 1
+    missingComponents:
+    - Item
+    - Physics
+    - Fixtures
+    - Pullable
 - proto: ClothingNeckCloakDolg
   entities:
   - uid: 2147
@@ -44661,6 +44688,18 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: ClothingOuterArmorSevaMonolithPriest
+  entities:
+  - uid: 10773
+    components:
+    - type: Transform
+      pos: -206.50768,-152.59023
+      parent: 1
+    missingComponents:
+    - Item
+    - Physics
+    - Fixtures
+    - Pullable
 - proto: Cobweb1
   entities:
   - uid: 2148
@@ -45217,11 +45256,14 @@ entities:
       supplyRampPosition: 2.4609375
 - proto: DeskBell
   entities:
-  - uid: 10694
+  - uid: 10755
     components:
     - type: Transform
-      pos: -172.75528,-70.186424
+      pos: -173.4132,-73.5378
       parent: 1
+    - type: Physics
+      angularDamping: 8
+      linearDamping: 8
     missingComponents:
     - Item
     - Pullable
@@ -45473,6 +45515,13 @@ entities:
       parent: 1
     missingComponents:
     - Pullable
+- proto: FaxMachineBase
+  entities:
+  - uid: 10751
+    components:
+    - type: Transform
+      pos: -204.5,-124.5
+      parent: 1
 - proto: FenceBetonBroken
   entities:
   - uid: 2266
@@ -58294,6 +58343,8 @@ entities:
   entities:
   - uid: 2090
     components:
+    - type: MetaData
+      name: Elevator
     - type: Transform
       pos: -203.5,-147.5
       parent: 1
@@ -58305,6 +58356,8 @@ entities:
       parent: 1
   - uid: 4682
     components:
+    - type: MetaData
+      name: Power Substation
     - type: Transform
       pos: -211.5,-147.5
       parent: 1
@@ -72321,6 +72374,8 @@ entities:
       parent: 1
   - uid: 2109
     components:
+    - type: MetaData
+      name: Infamary
     - type: Transform
       pos: -177.5,-69.5
       parent: 1
@@ -72347,18 +72402,27 @@ entities:
       parent: 1
   - uid: 7397
     components:
+    - type: MetaData
+      name: Bunks
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -186.5,-90.5
       parent: 1
   - uid: 7421
     components:
+    - type: MetaData
+      name: Cafeteria
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -175.5,-75.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Military
   - uid: 7453
     components:
+    - type: MetaData
+      name: Military Office
     - type: Transform
       pos: -168.5,-88.5
       parent: 1
@@ -72387,6 +72451,8 @@ entities:
       parent: 1
   - uid: 10677
     components:
+    - type: MetaData
+      name: Firing Range
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -172.5,-96.5
@@ -72419,17 +72485,30 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -175.5,-71.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -1172.4985
+      state: Opening
   - uid: 2249
     components:
+    - type: MetaData
+      name: Inner Compound
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -169.5,-71.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - SciBase
   - uid: 4665
     components:
+    - type: MetaData
+      name: Inner Compound
     - type: Transform
       pos: -166.5,-69.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - SciBase
   - uid: 4673
     components:
     - type: Transform
@@ -72546,6 +72625,8 @@ entities:
       parent: 1
   - uid: 7450
     components:
+    - type: MetaData
+      name: Bunks
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -193.5,-135.5
@@ -72562,6 +72643,8 @@ entities:
       parent: 1
   - uid: 7454
     components:
+    - type: MetaData
+      name: Meeting Room
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -200.5,-134.5
@@ -72585,6 +72668,8 @@ entities:
       parent: 1
   - uid: 7458
     components:
+    - type: MetaData
+      name: Meeting Room
     - type: Transform
       pos: -203.5,-137.5
       parent: 1
@@ -72596,6 +72681,8 @@ entities:
       parent: 1
   - uid: 7460
     components:
+    - type: MetaData
+      name: Power Substation
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -205.5,-141.5
@@ -72673,9 +72760,14 @@ entities:
   entities:
   - uid: 7464
     components:
+    - type: MetaData
+      name: Deans Office
     - type: Transform
       pos: -203.5,-127.5
       parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - SciHead
   - uid: 7465
     components:
     - type: Transform
@@ -72709,6 +72801,8 @@ entities:
   entities:
   - uid: 7470
     components:
+    - type: MetaData
+      name: Office
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -207.5,-131.5
@@ -72915,6 +73009,12 @@ entities:
           showEnts: False
           occludes: False
           ent: null
+  - uid: 10754
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -165.5,-73.5
+      parent: 1
 - proto: NPCResearchInstitutesPBEN
   entities:
   - uid: 7480
@@ -73491,6 +73591,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -172.5,-70.5
       parent: 1
+  - uid: 10763
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -192.5,-156.5
+      parent: 1
+  - uid: 10764
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -192.5,-157.5
+      parent: 1
 - proto: OldWoodTable4
   entities:
   - uid: 7565
@@ -73891,6 +74003,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -186.5,-68.5
+      parent: 1
+  - uid: 10759
+    components:
+    - type: Transform
+      pos: -170.5,-72.5
       parent: 1
   - uid: 14355
     components:
@@ -75194,6 +75311,13 @@ entities:
     components:
     - type: Transform
       pos: -163.43982,-100.98395
+      parent: 1
+- proto: PhoneInstrument
+  entities:
+  - uid: 10765
+    components:
+    - type: Transform
+      pos: -204.62907,-130.43744
       parent: 1
 - proto: PineTree01
   entities:
@@ -80374,6 +80498,16 @@ entities:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
+- proto: ShelfBar
+  entities:
+  - uid: 10762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -192.5,-156.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SignBiohazardMed
   entities:
   - uid: 8827
@@ -81056,6 +81190,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -193.5,-99.5
+      parent: 1
+  - uid: 10758
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -213.5,-131.5
       parent: 1
   - uid: 14360
     components:
@@ -94773,6 +94913,13 @@ entities:
     - type: Transform
       pos: -192.5,-160.5
       parent: 1
+- proto: StalkerDublicateSci
+  entities:
+  - uid: 7519
+    components:
+    - type: Transform
+      pos: -196.5,-137.5
+      parent: 1
 - proto: StalkerExplSafezoneTriggerIn
   entities:
   - uid: 12035
@@ -99286,13 +99433,6 @@ entities:
     - type: Transform
       pos: -129.5,-10.5
       parent: 1
-- proto: StalkerTeleportSci
-  entities:
-  - uid: 7519
-    components:
-    - type: Transform
-      pos: -196.5,-137.5
-      parent: 1
 - proto: StalkerTimedSpawner30
   entities:
   - uid: 12750
@@ -100532,6 +100672,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -175.5,-97.5
       parent: 1
+- proto: STClothingOuterArmorSSP99Project
+  entities:
+  - uid: 10772
+    components:
+    - type: Transform
+      pos: -207.5233,-151.54262
+      parent: 1
+    missingComponents:
+    - Item
+    - Physics
+    - Fixtures
+    - Pullable
 - proto: STComfyChair
   entities:
   - uid: 7556
@@ -100588,11 +100740,17 @@ entities:
       parent: 1
 - proto: STComputer
   entities:
-  - uid: 16568
+  - uid: 10749
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -170.5,-72.5
+      parent: 1
+  - uid: 10752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -171.5,-73.5
+      pos: -205.5,-124.5
       parent: 1
 - proto: STDivan
   entities:
@@ -107774,6 +107932,28 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -204.5,-149.5
       parent: 1
+- proto: STlatticefenceStraightDesktop
+  entities:
+  - uid: 10756
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -173.5,-72.5
+      parent: 1
+  - uid: 10757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -171.5,-72.5
+      parent: 1
+- proto: STlatticefenceStraightDesktopWindowed
+  entities:
+  - uid: 10694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -172.5,-72.5
+      parent: 1
 - proto: STMatrassBed2
   entities:
   - uid: 14340
@@ -108016,6 +108196,280 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -169.21973,-83.42578
+      parent: 1
+- proto: STPvpZoneTriggerFactionIn
+  entities:
+  - uid: 10695
+    components:
+    - type: Transform
+      pos: -159.5,-82.5
+      parent: 1
+  - uid: 10696
+    components:
+    - type: Transform
+      pos: -165.5,-66.5
+      parent: 1
+  - uid: 10697
+    components:
+    - type: Transform
+      pos: -162.5,-86.5
+      parent: 1
+  - uid: 10698
+    components:
+    - type: Transform
+      pos: -162.5,-85.5
+      parent: 1
+  - uid: 10699
+    components:
+    - type: Transform
+      pos: -162.5,-84.5
+      parent: 1
+  - uid: 10701
+    components:
+    - type: Transform
+      pos: -193.5,-64.5
+      parent: 1
+  - uid: 10702
+    components:
+    - type: Transform
+      pos: -192.5,-64.5
+      parent: 1
+  - uid: 10703
+    components:
+    - type: Transform
+      pos: -191.5,-64.5
+      parent: 1
+  - uid: 10706
+    components:
+    - type: Transform
+      pos: -198.5,-64.5
+      parent: 1
+  - uid: 10712
+    components:
+    - type: Transform
+      pos: -165.5,-66.5
+      parent: 1
+  - uid: 10713
+    components:
+    - type: Transform
+      pos: -165.5,-65.5
+      parent: 1
+  - uid: 10714
+    components:
+    - type: Transform
+      pos: -166.5,-65.5
+      parent: 1
+  - uid: 10715
+    components:
+    - type: Transform
+      pos: -167.5,-65.5
+      parent: 1
+  - uid: 10716
+    components:
+    - type: Transform
+      pos: -167.5,-66.5
+      parent: 1
+  - uid: 10717
+    components:
+    - type: Transform
+      pos: -166.5,-66.5
+      parent: 1
+  - uid: 10718
+    components:
+    - type: Transform
+      pos: -167.5,-67.5
+      parent: 1
+  - uid: 10719
+    components:
+    - type: Transform
+      pos: -166.5,-67.5
+      parent: 1
+  - uid: 10720
+    components:
+    - type: Transform
+      pos: -165.5,-67.5
+      parent: 1
+  - uid: 10721
+    components:
+    - type: Transform
+      pos: -204.5,-158.5
+      parent: 1
+  - uid: 10722
+    components:
+    - type: Transform
+      pos: -203.5,-158.5
+      parent: 1
+  - uid: 10723
+    components:
+    - type: Transform
+      pos: -202.5,-158.5
+      parent: 1
+  - uid: 10724
+    components:
+    - type: Transform
+      pos: -202.5,-159.5
+      parent: 1
+  - uid: 10725
+    components:
+    - type: Transform
+      pos: -203.5,-159.5
+      parent: 1
+  - uid: 10726
+    components:
+    - type: Transform
+      pos: -204.5,-159.5
+      parent: 1
+  - uid: 10727
+    components:
+    - type: Transform
+      pos: -204.5,-160.5
+      parent: 1
+  - uid: 10728
+    components:
+    - type: Transform
+      pos: -203.5,-160.5
+      parent: 1
+  - uid: 10729
+    components:
+    - type: Transform
+      pos: -202.5,-160.5
+      parent: 1
+  - uid: 10730
+    components:
+    - type: Transform
+      pos: -200.5,-136.5
+      parent: 1
+  - uid: 10731
+    components:
+    - type: Transform
+      pos: -199.5,-136.5
+      parent: 1
+  - uid: 10732
+    components:
+    - type: Transform
+      pos: -199.5,-136.5
+      parent: 1
+  - uid: 10733
+    components:
+    - type: Transform
+      pos: -198.5,-137.5
+      parent: 1
+  - uid: 10734
+    components:
+    - type: Transform
+      pos: -200.5,-137.5
+      parent: 1
+  - uid: 10735
+    components:
+    - type: Transform
+      pos: -199.5,-137.5
+      parent: 1
+  - uid: 10736
+    components:
+    - type: Transform
+      pos: -200.5,-138.5
+      parent: 1
+  - uid: 10737
+    components:
+    - type: Transform
+      pos: -199.5,-138.5
+      parent: 1
+  - uid: 10738
+    components:
+    - type: Transform
+      pos: -198.5,-138.5
+      parent: 1
+  - uid: 10739
+    components:
+    - type: Transform
+      pos: -198.5,-136.5
+      parent: 1
+  - uid: 10740
+    components:
+    - type: Transform
+      pos: -197.5,-136.5
+      parent: 1
+  - uid: 10741
+    components:
+    - type: Transform
+      pos: -196.5,-136.5
+      parent: 1
+  - uid: 10742
+    components:
+    - type: Transform
+      pos: -195.5,-136.5
+      parent: 1
+  - uid: 10743
+    components:
+    - type: Transform
+      pos: -195.5,-137.5
+      parent: 1
+  - uid: 10744
+    components:
+    - type: Transform
+      pos: -196.5,-137.5
+      parent: 1
+  - uid: 10745
+    components:
+    - type: Transform
+      pos: -197.5,-137.5
+      parent: 1
+  - uid: 10746
+    components:
+    - type: Transform
+      pos: -197.5,-138.5
+      parent: 1
+  - uid: 10747
+    components:
+    - type: Transform
+      pos: -196.5,-138.5
+      parent: 1
+  - uid: 10748
+    components:
+    - type: Transform
+      pos: -195.5,-138.5
+      parent: 1
+- proto: STPvpZoneTriggerFactionOut
+  entities:
+  - uid: 10700
+    components:
+    - type: Transform
+      pos: -160.5,-84.5
+      parent: 1
+  - uid: 10704
+    components:
+    - type: Transform
+      pos: -160.5,-85.5
+      parent: 1
+  - uid: 10705
+    components:
+    - type: Transform
+      pos: -160.5,-86.5
+      parent: 1
+  - uid: 10707
+    components:
+    - type: Transform
+      pos: -198.5,-62.5
+      parent: 1
+  - uid: 10708
+    components:
+    - type: Transform
+      pos: -193.5,-62.5
+      parent: 1
+  - uid: 10709
+    components:
+    - type: Transform
+      pos: -191.5,-62.5
+      parent: 1
+  - uid: 10710
+    components:
+    - type: Transform
+      pos: -192.5,-62.5
+      parent: 1
+  - uid: 10711
+    components:
+    - type: Transform
+      pos: -159.5,-84.5
       parent: 1
 - proto: STReinforcedWindow
   entities:
@@ -109227,19 +109681,11 @@ entities:
       parent: 1
     - type: PointLight
       enabled: True
-    - type: ApcPowerReceiver
-      needsPower: False
-  - uid: 14593
+  - uid: 10750
     components:
-    - type: MetaData
-      name: "'Научное Кофе!'"
     - type: Transform
       pos: -204.5,-144.5
       parent: 1
-    - type: PointLight
-      enabled: True
-    - type: ApcPowerReceiver
-      needsPower: False
   - uid: 14594
     components:
     - type: Transform
@@ -119384,6 +119830,44 @@ entities:
     components:
     - type: Transform
       pos: -19.744896,-89.38089
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 10766
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -207.5,-151.5
+      parent: 1
+  - uid: 10767
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -207.5,-151.5
+      parent: 1
+  - uid: 10768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -206.5,-152.5
+      parent: 1
+  - uid: 10769
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -206.5,-152.5
+      parent: 1
+  - uid: 10770
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -205.5,-153.5
+      parent: 1
+  - uid: 10771
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -205.5,-153.5
       parent: 1
 - proto: WoodDoorFallout
   entities:

--- a/Resources/Maps/_ST/World/Agroprom.yml
+++ b/Resources/Maps/_ST/World/Agroprom.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/26/2026 18:11:45
-  entityCount: 16284
+  time: 06/27/2026 08:31:29
+  entityCount: 16338
 maps:
 - 1
 grids:
@@ -94773,6 +94773,13 @@ entities:
     - type: Transform
       pos: -192.5,-160.5
       parent: 1
+- proto: StalkerDublicateSci
+  entities:
+  - uid: 7519
+    components:
+    - type: Transform
+      pos: -196.5,-137.5
+      parent: 1
 - proto: StalkerExplSafezoneTriggerIn
   entities:
   - uid: 12035
@@ -99285,13 +99292,6 @@ entities:
     components:
     - type: Transform
       pos: -129.5,-10.5
-      parent: 1
-- proto: StalkerTeleportSci
-  entities:
-  - uid: 7519
-    components:
-    - type: Transform
-      pos: -196.5,-137.5
       parent: 1
 - proto: StalkerTimedSpawner30
   entities:
@@ -108016,6 +108016,280 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -169.21973,-83.42578
+      parent: 1
+- proto: STPvpZoneTriggerFactionIn
+  entities:
+  - uid: 10695
+    components:
+    - type: Transform
+      pos: -159.5,-82.5
+      parent: 1
+  - uid: 10696
+    components:
+    - type: Transform
+      pos: -165.5,-66.5
+      parent: 1
+  - uid: 10697
+    components:
+    - type: Transform
+      pos: -162.5,-86.5
+      parent: 1
+  - uid: 10698
+    components:
+    - type: Transform
+      pos: -162.5,-85.5
+      parent: 1
+  - uid: 10699
+    components:
+    - type: Transform
+      pos: -162.5,-84.5
+      parent: 1
+  - uid: 10701
+    components:
+    - type: Transform
+      pos: -193.5,-64.5
+      parent: 1
+  - uid: 10702
+    components:
+    - type: Transform
+      pos: -192.5,-64.5
+      parent: 1
+  - uid: 10703
+    components:
+    - type: Transform
+      pos: -191.5,-64.5
+      parent: 1
+  - uid: 10706
+    components:
+    - type: Transform
+      pos: -198.5,-64.5
+      parent: 1
+  - uid: 10712
+    components:
+    - type: Transform
+      pos: -165.5,-66.5
+      parent: 1
+  - uid: 10713
+    components:
+    - type: Transform
+      pos: -165.5,-65.5
+      parent: 1
+  - uid: 10714
+    components:
+    - type: Transform
+      pos: -166.5,-65.5
+      parent: 1
+  - uid: 10715
+    components:
+    - type: Transform
+      pos: -167.5,-65.5
+      parent: 1
+  - uid: 10716
+    components:
+    - type: Transform
+      pos: -167.5,-66.5
+      parent: 1
+  - uid: 10717
+    components:
+    - type: Transform
+      pos: -166.5,-66.5
+      parent: 1
+  - uid: 10718
+    components:
+    - type: Transform
+      pos: -167.5,-67.5
+      parent: 1
+  - uid: 10719
+    components:
+    - type: Transform
+      pos: -166.5,-67.5
+      parent: 1
+  - uid: 10720
+    components:
+    - type: Transform
+      pos: -165.5,-67.5
+      parent: 1
+  - uid: 10721
+    components:
+    - type: Transform
+      pos: -204.5,-158.5
+      parent: 1
+  - uid: 10722
+    components:
+    - type: Transform
+      pos: -203.5,-158.5
+      parent: 1
+  - uid: 10723
+    components:
+    - type: Transform
+      pos: -202.5,-158.5
+      parent: 1
+  - uid: 10724
+    components:
+    - type: Transform
+      pos: -202.5,-159.5
+      parent: 1
+  - uid: 10725
+    components:
+    - type: Transform
+      pos: -203.5,-159.5
+      parent: 1
+  - uid: 10726
+    components:
+    - type: Transform
+      pos: -204.5,-159.5
+      parent: 1
+  - uid: 10727
+    components:
+    - type: Transform
+      pos: -204.5,-160.5
+      parent: 1
+  - uid: 10728
+    components:
+    - type: Transform
+      pos: -203.5,-160.5
+      parent: 1
+  - uid: 10729
+    components:
+    - type: Transform
+      pos: -202.5,-160.5
+      parent: 1
+  - uid: 10730
+    components:
+    - type: Transform
+      pos: -200.5,-136.5
+      parent: 1
+  - uid: 10731
+    components:
+    - type: Transform
+      pos: -199.5,-136.5
+      parent: 1
+  - uid: 10732
+    components:
+    - type: Transform
+      pos: -199.5,-136.5
+      parent: 1
+  - uid: 10733
+    components:
+    - type: Transform
+      pos: -198.5,-137.5
+      parent: 1
+  - uid: 10734
+    components:
+    - type: Transform
+      pos: -200.5,-137.5
+      parent: 1
+  - uid: 10735
+    components:
+    - type: Transform
+      pos: -199.5,-137.5
+      parent: 1
+  - uid: 10736
+    components:
+    - type: Transform
+      pos: -200.5,-138.5
+      parent: 1
+  - uid: 10737
+    components:
+    - type: Transform
+      pos: -199.5,-138.5
+      parent: 1
+  - uid: 10738
+    components:
+    - type: Transform
+      pos: -198.5,-138.5
+      parent: 1
+  - uid: 10739
+    components:
+    - type: Transform
+      pos: -198.5,-136.5
+      parent: 1
+  - uid: 10740
+    components:
+    - type: Transform
+      pos: -197.5,-136.5
+      parent: 1
+  - uid: 10741
+    components:
+    - type: Transform
+      pos: -196.5,-136.5
+      parent: 1
+  - uid: 10742
+    components:
+    - type: Transform
+      pos: -195.5,-136.5
+      parent: 1
+  - uid: 10743
+    components:
+    - type: Transform
+      pos: -195.5,-137.5
+      parent: 1
+  - uid: 10744
+    components:
+    - type: Transform
+      pos: -196.5,-137.5
+      parent: 1
+  - uid: 10745
+    components:
+    - type: Transform
+      pos: -197.5,-137.5
+      parent: 1
+  - uid: 10746
+    components:
+    - type: Transform
+      pos: -197.5,-138.5
+      parent: 1
+  - uid: 10747
+    components:
+    - type: Transform
+      pos: -196.5,-138.5
+      parent: 1
+  - uid: 10748
+    components:
+    - type: Transform
+      pos: -195.5,-138.5
+      parent: 1
+- proto: STPvpZoneTriggerFactionOut
+  entities:
+  - uid: 10700
+    components:
+    - type: Transform
+      pos: -160.5,-84.5
+      parent: 1
+  - uid: 10704
+    components:
+    - type: Transform
+      pos: -160.5,-85.5
+      parent: 1
+  - uid: 10705
+    components:
+    - type: Transform
+      pos: -160.5,-86.5
+      parent: 1
+  - uid: 10707
+    components:
+    - type: Transform
+      pos: -198.5,-62.5
+      parent: 1
+  - uid: 10708
+    components:
+    - type: Transform
+      pos: -193.5,-62.5
+      parent: 1
+  - uid: 10709
+    components:
+    - type: Transform
+      pos: -191.5,-62.5
+      parent: 1
+  - uid: 10710
+    components:
+    - type: Transform
+      pos: -192.5,-62.5
+      parent: 1
+  - uid: 10711
+    components:
+    - type: Transform
+      pos: -159.5,-84.5
       parent: 1
 - proto: STReinforcedWindow
   entities:


### PR DESCRIPTION
## What I changed
Fixes PVP Flags for Eco Compound so it not stuck in Yellow Zone

Some minor fixes for objects and names within the compound.

## Changelog
author: @SnekiChaos 

- tweak: Fixed PVP Flags for Eco Compound
- tweak: Fixed some unpowered objects around the Compound
- tweak: Labeled some doors for immersion
- tweak: Added divider to Eco counter
- tweak: Added few minor details to spruce up the Eco Compound
- tweak: Switched old unused Stash for one from Yantar Bunker.

## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
