### PR TITLE
Temporary Fix of the 325 and 625 revolver being completely useless issue

### DIFF
--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Revolvers/SW_325.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Revolvers/SW_325.yml
@@ -24,8 +24,8 @@
     - type: RevolverAmmoProvider
       whitelist:
         tags:
-          - Cartridge45ACP
-          - STSpeedLoader45ACP
+        - Cartridge357Magnum
+        - SpeedLoader357Magnum
       proto: null
       capacity: 6
       chambers: [ null, null, null, null, null, null ]

--- a/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Revolvers/SW_625.yml
+++ b/Resources/Prototypes/_Stalker/Entities/Objects/Weapons/Guns/Revolvers/SW_625.yml
@@ -26,8 +26,8 @@
     - type: RevolverAmmoProvider
       whitelist:
         tags:
-          - Cartridge45ACP
-          - STSpeedLoader45ACP
+        - Cartridge357Magnum
+        - SpeedLoader357Magnum
       proto: null
       capacity: 6
       chambers: [ null, null, null, null, null, null ]


### PR DESCRIPTION


I just changed them to use the still underpowered .357 magnum round.



## What I changed
Changed the 325 & 625 Revolvers to use .357 Magnum instead of .45 ACP as .45 ACP is just reskinned 9mm, making them useless.
This is really just a test and if it works I really should change the description of both Revolvers to say they use 357...
## Changelog
-Tweak: Switched the accepted ammo type of the 325 & 625 Revolvers to accept .357 Magnum rounds and speedloaders instead of .45 ACP





author: SoulSirViver




## Make sure you check and agree to the following
- [X] Yes, I ran my code and tested that the changes worked
- [X] Yes, I checked that there were no errors in the console output of the client and server after my changes
- [X] I agree that by submitting a PR I agree to the terms of the [license](https://github.com/coolmankid12345/stalker-14-EN/blob/master/LICENSE.TXT).
- [X] I have checked and confirm that all images and audio files that I have added to the PR belong to me or are under an open license
